### PR TITLE
[CUMULUS-247] Resolve vulnerability in marked npm module.

### DIFF
--- a/gibs-ops-api/package-lock.json
+++ b/gibs-ops-api/package-lock.json
@@ -1,5 +1,6 @@
 {
-	"requires": true,
+	"name": "gibs-ops-api",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@types/bluebird": {
@@ -10,19 +11,12 @@
 		"@types/express": {
 			"version": "4.0.36",
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.36.tgz",
-			"integrity": "sha512-bT9q2eqH/E72AGBQKT50dh6AXzheTqigGZ1GwDiwmx7vfHff0bZOrvUWjvGpNWPNkRmX1vDF6wonG6rlpBHb1A==",
-			"requires": {
-				"@types/express-serve-static-core": "4.0.49",
-				"@types/serve-static": "1.7.31"
-			}
+			"integrity": "sha512-bT9q2eqH/E72AGBQKT50dh6AXzheTqigGZ1GwDiwmx7vfHff0bZOrvUWjvGpNWPNkRmX1vDF6wonG6rlpBHb1A=="
 		},
 		"@types/express-serve-static-core": {
 			"version": "4.0.49",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.49.tgz",
-			"integrity": "sha512-b7mVHoURu1xaP/V6xw1sYwyv9V0EZ7euyi+sdnbnTZxEkAh4/hzPsI6Eflq+ZzHQ/Tgl7l16Jz+0oz8F46MLnA==",
-			"requires": {
-				"@types/node": "8.0.21"
-			}
+			"integrity": "sha512-b7mVHoURu1xaP/V6xw1sYwyv9V0EZ7euyi+sdnbnTZxEkAh4/hzPsI6Eflq+ZzHQ/Tgl7l16Jz+0oz8F46MLnA=="
 		},
 		"@types/mime": {
 			"version": "1.3.1",
@@ -37,43 +31,36 @@
 		"@types/serve-static": {
 			"version": "1.7.31",
 			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.31.tgz",
-			"integrity": "sha1-FUVt6NmNa0z/Mb5savdJKuY/Uho=",
-			"requires": {
-				"@types/express-serve-static-core": "4.0.49",
-				"@types/mime": "1.3.1"
-			}
+			"integrity": "sha1-FUVt6NmNa0z/Mb5savdJKuY/Uho="
 		},
 		"abbrev": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-			"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+			"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-			"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-			"requires": {
-				"mime-types": "2.1.16",
-				"negotiator": "0.6.1"
-			}
+			"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo="
 		},
 		"acorn": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+			"dev": true
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"requires": {
-				"acorn": "4.0.13"
-			},
+			"dev": true,
 			"dependencies": {
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
@@ -81,14 +68,13 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-			"requires": {
-				"acorn": "3.3.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -101,30 +87,25 @@
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-			"requires": {
-				"co": "4.6.0",
-				"json-stable-stringify": "1.0.1"
-			}
+			"dev": true
 		},
 		"ajv-keywords": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+			"dev": true
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
-			}
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -140,39 +121,30 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
-			}
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-			"requires": {
-				"sprintf-js": "1.0.3"
-			}
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
 		},
 		"aria-query": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.3.0.tgz",
 			"integrity": "sha1-y4qZhOKGJxHIPICt5bj1yg3itGc=",
-			"requires": {
-				"ast-types-flow": "0.0.7"
-			}
+			"dev": true
 		},
 		"arr-diff": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "1.1.0"
-			}
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"array-flatten": {
 			"version": "1.1.1",
@@ -183,119 +155,83 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"requires": {
-				"array-uniq": "1.0.3"
-			}
+			"dev": true
 		},
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
 		},
 		"array.prototype.find": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
 			"integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
-			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.8.0"
-			}
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-		},
-		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asn1.js": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
 			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
-			}
+			"dev": true
 		},
 		"assert": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"requires": {
-				"util": "0.10.3"
-			}
-		},
-		"assert-plus": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-			"integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+			"integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+			"dev": true
 		},
 		"ast-types": {
 			"version": "0.9.6",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-			"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+			"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+			"dev": true
 		},
 		"ast-types-flow": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+			"dev": true
 		},
 		"async": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-			"requires": {
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
 		},
 		"aws-sdk": {
 			"version": "2.98.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.98.0.tgz",
-			"integrity": "sha1-kK0CPXM4ndFex736+TLsq2VEVxE=",
-			"requires": {
-				"buffer": "4.9.1",
-				"crypto-browserify": "1.0.9",
-				"events": "1.1.1",
-				"jmespath": "0.15.0",
-				"querystring": "0.2.0",
-				"sax": "1.2.1",
-				"url": "0.10.3",
-				"uuid": "3.0.1",
-				"xml2js": "0.4.17",
-				"xmlbuilder": "4.2.1"
-			}
+			"integrity": "sha1-kK0CPXM4ndFex736+TLsq2VEVxE="
 		},
 		"aws-serverless-express": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/aws-serverless-express/-/aws-serverless-express-2.2.0.tgz",
-			"integrity": "sha1-KI5pFdRP9oZvnxmTI3zElICKPDY=",
-			"requires": {
-				"binary-case": "1.1.3"
-			}
+			"integrity": "sha1-KI5pFdRP9oZvnxmTI3zElICKPDY="
 		},
 		"aws-sign2": {
 			"version": "0.6.0",
@@ -311,215 +247,115 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
-			}
+			"dev": true
 		},
 		"babel-core": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
 			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-			"requires": {
-				"babel-code-frame": "6.22.0",
-				"babel-generator": "6.25.0",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
-				"convert-source-map": "1.5.0",
-				"debug": "2.6.8",
-				"json5": "0.5.1",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.7",
-				"slash": "1.0.0",
-				"source-map": "0.5.6"
-			}
+			"dev": true
 		},
 		"babel-eslint": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
 			"integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
-			"requires": {
-				"babel-code-frame": "6.22.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4"
-			}
+			"dev": true
 		},
 		"babel-generator": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
 			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.4",
-				"source-map": "0.5.6",
-				"trim-right": "1.0.1"
-			}
+			"dev": true
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-call-delegate": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-define-map": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-helper-explode-assignable-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-function-name": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-get-function-arity": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-hoist-variables": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-optimise-call-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-regex": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-helper-remap-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helper-replace-supers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-helpers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-loader": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
 			"integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
-			"requires": {
-				"find-cache-dir": "0.1.1",
-				"loader-utils": "0.2.17",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"babel-messages": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-extensible-destructuring": {
 			"version": "4.1.0",
@@ -529,404 +365,233 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-classes": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"requires": {
-				"babel-helper-define-map": "6.24.1",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-destructuring": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-for-of": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-function-name": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-literals": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-object-super": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-parameters": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-spread": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-template-literals": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"requires": {
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"regexpu-core": "2.0.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-exponentiation-operator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
 			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-			"requires": {
-				"regenerator-transform": "0.9.11"
-			}
+			"dev": true
 		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
-			}
+			"dev": true
 		},
 		"babel-polyfill": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"core-js": "2.5.0",
-				"regenerator-runtime": "0.10.5"
-			}
+			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0="
 		},
 		"babel-preset-env": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
 			"integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.24.1",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.24.1",
-				"browserslist": "2.3.2",
-				"invariant": "2.2.2",
-				"semver": "5.4.1"
-			}
+			"dev": true
 		},
 		"babel-register": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
 			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-			"requires": {
-				"babel-core": "6.25.0",
-				"babel-runtime": "6.25.0",
-				"core-js": "2.5.0",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.15"
-			}
+			"dev": true
 		},
 		"babel-runtime": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
-			"requires": {
-				"core-js": "2.5.0",
-				"regenerator-runtime": "0.10.5"
-			}
+			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw="
 		},
 		"babel-template": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-traverse": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-			"requires": {
-				"babel-code-frame": "6.22.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
-				"debug": "2.6.8",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4"
-			}
+			"dev": true
 		},
 		"babel-types": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.4",
-				"to-fast-properties": "1.0.3"
-			}
+			"dev": true
 		},
 		"babylon": {
 			"version": "6.17.4",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+			"dev": true
 		},
 		"base64-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
 			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
 		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"optional": true,
-			"requires": {
-				"tweetnacl": "0.14.5"
-			}
-		},
 		"big.js": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-			"integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
+			"integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
+			"dev": true
 		},
 		"binary-case": {
 			"version": "1.1.3",
@@ -936,178 +601,115 @@
 		"binary-extensions": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-			"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+			"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+			"dev": true
 		},
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+			"dev": true
 		},
 		"body-parser": {
 			"version": "1.17.2",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
 			"integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
-			"requires": {
-				"bytes": "2.4.0",
-				"content-type": "1.0.2",
-				"debug": "2.6.7",
-				"depd": "1.1.1",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.15",
-				"on-finished": "2.3.0",
-				"qs": "6.4.0",
-				"raw-body": "2.2.0",
-				"type-is": "1.6.15"
-			},
 			"dependencies": {
 				"debug": {
 					"version": "2.6.7",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-					"integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-					"requires": {
-						"ms": "2.0.0"
-					}
+					"integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
 				}
-			}
-		},
-		"boom": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"requires": {
-				"hoek": "2.16.3"
-			}
-		},
-		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-			"requires": {
-				"balanced-match": "1.0.0",
-				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
-			}
+			"dev": true
 		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
 		},
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
 		},
 		"browserify-aes": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
 			"integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.0",
-				"inherits": "2.0.3"
-			}
+			"dev": true
 		},
 		"browserify-cipher": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-			"requires": {
-				"browserify-aes": "1.0.6",
-				"browserify-des": "1.0.0",
-				"evp_bytestokey": "1.0.0"
-			}
+			"dev": true
 		},
 		"browserify-des": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
-			}
+			"dev": true
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.5"
-			}
+			"dev": true
 		},
 		"browserify-sign": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.0"
-			}
+			"dev": true
 		},
 		"browserify-zlib": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-			"requires": {
-				"pako": "0.2.9"
-			}
+			"dev": true
 		},
 		"browserslist": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.2.tgz",
 			"integrity": "sha512-arvLUwBTsmpfmyMfoBQH8WWICiyaVkMxJsft73/rTRU80rAPSXsi3M0uYBcUH22w7MG475eET31F4M0+31w81g==",
-			"requires": {
-				"caniuse-lite": "1.0.30000715",
-				"electron-to-chromium": "1.3.18"
-			}
+			"dev": true
 		},
 		"buffer": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-			"requires": {
-				"base64-js": "1.2.1",
-				"ieee754": "1.1.8",
-				"isarray": "1.0.0"
-			}
+			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+			"dev": true
 		},
 		"bytes": {
 			"version": "2.4.0",
@@ -1118,33 +720,31 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"requires": {
-				"callsites": "0.2.0"
-			}
+			"dev": true
 		},
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"camel-case": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"requires": {
-				"no-case": "2.3.1",
-				"upper-case": "1.1.3"
-			}
+			"dev": true
 		},
 		"camelcase": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000715",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
-			"integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA="
+			"integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA=",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1155,84 +755,60 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
-			}
+			"dev": true
 		},
 		"chai": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
 			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-			"requires": {
-				"assertion-error": "1.0.2",
-				"deep-eql": "0.1.3",
-				"type-detect": "1.0.0"
-			}
+			"dev": true
 		},
 		"chai-as-promised": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
 			"integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
-			"requires": {
-				"check-error": "1.0.2"
-			}
+			"dev": true
 		},
 		"chai-immutable": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/chai-immutable/-/chai-immutable-1.6.0.tgz",
-			"integrity": "sha1-nsAL3WeUixOyD8u4nL9K8s5vkkc="
+			"integrity": "sha1-nsAL3WeUixOyD8u4nL9K8s5vkkc=",
+			"dev": true
 		},
 		"chalk": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
-			}
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
 		},
 		"charenc": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -1240,96 +816,70 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
-			}
+			"dev": true
 		},
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"clean-css": {
 			"version": "4.1.7",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.7.tgz",
 			"integrity": "sha1-ua6k+FZ5iJzz6ui0A0nsTr390DI=",
-			"requires": {
-				"source-map": "0.5.6"
-			}
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-			"requires": {
-				"restore-cursor": "1.0.1"
-			}
+			"dev": true
 		},
 		"cli-width": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wrap-ansi": "2.1.0"
-			}
-		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-			"requires": {
-				"delayed-stream": "1.0.0"
-			}
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
 		},
 		"commander": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
 		},
 		"compressible": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
-			"integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
-			"requires": {
-				"mime-db": "1.29.0"
-			}
+			"integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo="
 		},
 		"compression": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
 			"integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
-			"requires": {
-				"accepts": "1.3.3",
-				"bytes": "2.5.0",
-				"compressible": "2.0.11",
-				"debug": "2.6.8",
-				"on-headers": "1.0.1",
-				"safe-buffer": "5.1.1",
-				"vary": "1.1.1"
-			},
 			"dependencies": {
 				"bytes": {
 					"version": "2.5.0",
@@ -1338,40 +888,23 @@
 				}
 			}
 		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
 		"concat-stream": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
-			}
+			"dev": true
 		},
 		"configstore": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
 			"integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1",
-				"os-tmpdir": "1.0.2",
-				"osenv": "0.1.4",
-				"uuid": "2.0.3",
-				"write-file-atomic": "1.3.4",
-				"xdg-basedir": "2.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+					"dev": true
 				}
 			}
 		},
@@ -1379,19 +912,19 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"requires": {
-				"date-now": "0.1.4"
-			}
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+			"dev": true
 		},
 		"contains-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -1406,7 +939,8 @@
 		"convert-source-map": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"dev": true
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -1422,16 +956,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
 			"integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
-			"requires": {
-				"bluebird": "2.11.0",
-				"fs-extra": "0.26.7",
-				"glob": "6.0.4",
-				"is-glob": "3.1.0",
-				"loader-utils": "0.2.17",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"node-dir": "0.1.17"
-			}
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.0",
@@ -1441,62 +966,37 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cors": {
 			"version": "2.8.4",
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-			"integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-			"requires": {
-				"object-assign": "4.1.1",
-				"vary": "1.1.1"
-			}
+			"integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY="
 		},
 		"create-ecdh": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0"
-			}
+			"dev": true
 		},
 		"create-hash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"sha.js": "2.4.8"
-			}
+			"dev": true
 		},
 		"create-hmac": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.8"
-			}
+			"dev": true
 		},
 		"crypt": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-		},
-		"cryptiles": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"requires": {
-				"boom": "2.10.1"
-			}
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+			"dev": true
 		},
 		"crypto-browserify": {
 			"version": "1.0.9",
@@ -1507,100 +1007,62 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"requires": {
-				"es5-ext": "0.10.27"
-			}
+			"dev": true
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-			"integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
+			"integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+			"dev": true
 		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+			"dev": true
 		},
 		"debug": {
 			"version": "2.6.8",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-			"requires": {
-				"ms": "2.0.0"
-			}
+			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
 		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"deep-eql": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
 			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-			"requires": {
-				"type-detect": "0.1.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"type-detect": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+					"dev": true
 				}
 			}
-		},
-		"deep-extend": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
-			}
+			"dev": true
 		},
 		"del": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.6.1"
-			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.1",
@@ -1611,10 +1073,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
-			}
+			"dev": true
 		},
 		"destroy": {
 			"version": "1.0.4",
@@ -1625,63 +1084,43 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"requires": {
-				"repeating": "2.0.1"
-			}
+			"dev": true
 		},
 		"diff": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.0",
-				"randombytes": "2.0.5"
-			}
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
 			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-			"requires": {
-				"esutils": "2.0.2",
-				"isarray": "1.0.0"
-			}
+			"dev": true
 		},
 		"domain-browser": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+			"dev": true
 		},
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
 		},
 		"duplexify": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
 			"integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-			"requires": {
-				"end-of-stream": "1.4.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"stream-shift": "1.0.0"
-			}
-		},
-		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"optional": true,
-			"requires": {
-				"jsbn": "0.1.1"
-			}
+			"dev": true
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -1692,14 +1131,6 @@
 			"version": "13.3.1",
 			"resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.3.1.tgz",
 			"integrity": "sha1-xTCuqa+xfqkcPQpW8fERukm8kjk=",
-			"requires": {
-				"agentkeepalive": "2.2.0",
-				"chalk": "1.1.3",
-				"lodash": "2.4.2",
-				"lodash.get": "4.4.2",
-				"lodash.isempty": "4.4.0",
-				"lodash.trimend": "4.5.1"
-			},
 			"dependencies": {
 				"lodash": {
 					"version": "2.4.2",
@@ -1711,31 +1142,26 @@
 		"electron-to-chromium": {
 			"version": "1.3.18",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
-			"integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw="
+			"integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
+			"dev": true
 		},
 		"elliptic": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
-			}
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
+			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+			"dev": true
 		},
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
 		},
 		"encodeurl": {
 			"version": "1.0.1",
@@ -1746,136 +1172,85 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-			"requires": {
-				"once": "1.4.0"
-			}
+			"dev": true
 		},
 		"enhanced-resolve": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"memory-fs": "0.4.1",
-				"object-assign": "4.1.1",
-				"tapable": "0.2.8"
-			}
+			"dev": true
 		},
 		"errno": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-			"requires": {
-				"prr": "0.0.0"
-			}
+			"dev": true
 		},
 		"error-ex": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"requires": {
-				"is-arrayish": "0.2.1"
-			}
+			"dev": true
 		},
 		"es-abstract": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
 			"integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
-			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.0",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
-			}
+			"dev": true
 		},
 		"es-to-primitive": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
-			}
+			"dev": true
 		},
 		"es5-ext": {
 			"version": "0.10.27",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
 			"integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
-			"requires": {
-				"es6-iterator": "2.0.1",
-				"es6-symbol": "3.1.1"
-			}
+			"dev": true
 		},
 		"es6-iterator": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
 			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.27",
-				"es6-symbol": "3.1.1"
-			}
+			"dev": true
 		},
 		"es6-map": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.27",
-				"es6-iterator": "2.0.1",
-				"es6-set": "0.1.5",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
-			}
+			"dev": true
 		},
 		"es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+			"dev": true
 		},
 		"es6-set": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.27",
-				"es6-iterator": "2.0.1",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
-			}
+			"dev": true
 		},
 		"es6-symbol": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.27"
-			}
+			"dev": true
 		},
 		"es6-templates": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
 			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-			"requires": {
-				"recast": "0.11.23",
-				"through": "2.3.8"
-			}
+			"dev": true
 		},
 		"es6-weak-map": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.27",
-				"es6-iterator": "2.0.1",
-				"es6-symbol": "3.1.1"
-			}
+			"dev": true
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -1891,67 +1266,19 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-			"requires": {
-				"es6-map": "0.1.5",
-				"es6-weak-map": "2.0.2",
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
-			}
+			"dev": true
 		},
 		"eslint": {
 			"version": "3.19.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
 			"integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-			"requires": {
-				"babel-code-frame": "6.22.0",
-				"chalk": "1.1.3",
-				"concat-stream": "1.6.0",
-				"debug": "2.6.8",
-				"doctrine": "2.0.0",
-				"escope": "3.6.0",
-				"espree": "3.5.0",
-				"esquery": "1.0.0",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"glob": "7.1.2",
-				"globals": "9.18.0",
-				"ignore": "3.3.3",
-				"imurmurhash": "0.1.4",
-				"inquirer": "0.12.0",
-				"is-my-json-valid": "2.16.0",
-				"is-resolvable": "1.0.0",
-				"js-yaml": "3.9.1",
-				"json-stable-stringify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "1.2.1",
-				"progress": "1.1.8",
-				"require-uncached": "1.0.3",
-				"shelljs": "0.7.8",
-				"strip-bom": "3.0.0",
-				"strip-json-comments": "2.0.1",
-				"table": "3.8.3",
-				"text-table": "0.2.0",
-				"user-home": "2.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+					"dev": true
 				}
 			}
 		},
@@ -1959,66 +1286,43 @@
 			"version": "14.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-14.1.0.tgz",
 			"integrity": "sha1-NV0pAEC7+OAL+LSxn0twy+fCMX8=",
-			"requires": {
-				"eslint-config-airbnb-base": "11.3.1"
-			}
+			"dev": true
 		},
 		"eslint-config-airbnb-base": {
 			"version": "11.3.1",
 			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz",
 			"integrity": "sha512-BXVH7PV5yiLjnkv49iOLJ8dWp+ljZf310ytQpqwrunFADiEbWRyN0tPGDU36FgEbdLvhJDWcJOngYDzPF4shDw==",
-			"requires": {
-				"eslint-restricted-globals": "0.1.1"
-			}
+			"dev": true
 		},
 		"eslint-config-standard": {
 			"version": "10.2.1",
 			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
-			"integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE="
+			"integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
 			"integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
-			"requires": {
-				"debug": "2.6.8",
-				"resolve": "1.4.0"
-			}
+			"dev": true
 		},
 		"eslint-module-utils": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
 			"integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-			"requires": {
-				"debug": "2.6.8",
-				"pkg-dir": "1.0.0"
-			}
+			"dev": true
 		},
 		"eslint-plugin-import": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
 			"integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
-			"requires": {
-				"builtin-modules": "1.1.1",
-				"contains-path": "0.1.0",
-				"debug": "2.6.8",
-				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "0.3.1",
-				"eslint-module-utils": "2.1.1",
-				"has": "1.0.1",
-				"lodash.cond": "4.5.2",
-				"minimatch": "3.0.4",
-				"read-pkg-up": "2.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"doctrine": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-					"requires": {
-						"esutils": "2.0.2",
-						"isarray": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -2026,80 +1330,59 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz",
 			"integrity": "sha1-d5uw/nsI2lZKQiYkkR3hAGHgSO4=",
-			"requires": {
-				"aria-query": "0.3.0",
-				"ast-types-flow": "0.0.7",
-				"damerau-levenshtein": "1.0.4",
-				"emoji-regex": "6.5.1",
-				"jsx-ast-utils": "1.4.1",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"eslint-plugin-node": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
-			"integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
-			"requires": {
-				"ignore": "3.3.3",
-				"minimatch": "3.0.4",
-				"object-assign": "4.1.1",
-				"resolve": "1.4.0",
-				"semver": "5.3.0"
-			},
+			"integrity": "sha1-wEOQq428u2iHF0Aj1vOnJ2nmO5c=",
+			"dev": true,
 			"dependencies": {
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-promise": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
-			"integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o="
+			"integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
+			"dev": true
 		},
 		"eslint-plugin-react": {
 			"version": "6.10.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
 			"integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
-			"requires": {
-				"array.prototype.find": "2.0.4",
-				"doctrine": "1.5.0",
-				"has": "1.0.1",
-				"jsx-ast-utils": "1.4.1",
-				"object.assign": "4.0.4"
-			},
+			"dev": true,
 			"dependencies": {
 				"doctrine": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-					"requires": {
-						"esutils": "2.0.2",
-						"isarray": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-standard": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-			"integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI="
+			"integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+			"dev": true
 		},
 		"eslint-restricted-globals": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
-			"integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc="
+			"integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
 			"integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
-			"requires": {
-				"acorn": "5.1.1",
-				"acorn-jsx": "3.0.1"
-			}
+			"dev": true
 		},
 		"esprima": {
 			"version": "4.0.0",
@@ -2110,28 +1393,25 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-			"requires": {
-				"estraverse": "4.2.0"
-			}
+			"dev": true
 		},
 		"esrecurse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.0",
@@ -2142,24 +1422,13 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.27"
-			}
+			"dev": true
 		},
 		"event-stream": {
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"requires": {
-				"duplexer": "0.1.1",
-				"from": "0.1.7",
-				"map-stream": "0.1.0",
-				"pause-stream": "0.0.11",
-				"split": "0.3.3",
-				"stream-combiner": "0.0.4",
-				"through": "2.3.8"
-			}
+			"dev": true
 		},
 		"events": {
 			"version": "1.1.1",
@@ -2170,70 +1439,36 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
 			"integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-			"requires": {
-				"create-hash": "1.1.3"
-			}
+			"dev": true
 		},
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"requires": {
-				"is-posix-bracket": "0.1.1"
-			}
+			"dev": true
 		},
 		"expand-range": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"requires": {
-				"fill-range": "2.2.3"
-			}
+			"dev": true
 		},
 		"expect.js": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
-			"integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s="
+			"integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+			"dev": true
 		},
 		"express": {
 			"version": "4.15.4",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
 			"integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
-			"requires": {
-				"accepts": "1.3.3",
-				"array-flatten": "1.1.1",
-				"content-disposition": "0.5.2",
-				"content-type": "1.0.2",
-				"cookie": "0.3.1",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.8",
-				"depd": "1.1.1",
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"etag": "1.8.0",
-				"finalhandler": "1.0.4",
-				"fresh": "0.5.0",
-				"merge-descriptors": "1.0.1",
-				"methods": "1.1.2",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.1",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "1.1.5",
-				"qs": "6.5.0",
-				"range-parser": "1.2.0",
-				"send": "0.15.4",
-				"serve-static": "1.12.4",
-				"setprototypeof": "1.0.3",
-				"statuses": "1.3.1",
-				"type-is": "1.6.15",
-				"utils-merge": "1.0.0",
-				"vary": "1.1.1"
-			},
 			"dependencies": {
 				"qs": {
 					"version": "6.5.0",
@@ -2246,13 +1481,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/express-validator/-/express-validator-3.2.1.tgz",
 			"integrity": "sha1-RWA+fu5pMYXCGY+969QUkl/9NSQ=",
-			"requires": {
-				"@types/bluebird": "3.5.8",
-				"@types/express": "4.0.36",
-				"bluebird": "3.5.0",
-				"lodash": "4.17.4",
-				"validator": "6.2.1"
-			},
 			"dependencies": {
 				"bluebird": {
 					"version": "3.5.0",
@@ -2269,137 +1497,98 @@
 		"extensible-runtime": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/extensible-runtime/-/extensible-runtime-4.1.0.tgz",
-			"integrity": "sha1-ablqwqV22GQ+xYUkLeZ1YGl53P8=",
-			"requires": {
-				"immutable": "3.8.1"
-			}
+			"integrity": "sha1-ablqwqV22GQ+xYUkLeZ1YGl53P8="
 		},
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"requires": {
-				"is-extglob": "1.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				}
 			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fastparse": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+			"dev": true
 		},
 		"figures": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-			"requires": {
-				"escape-string-regexp": "1.0.5",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"file-entry-cache": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-			"requires": {
-				"flat-cache": "1.2.2",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
-			}
+			"dev": true
 		},
 		"finalhandler": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-			"integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
-			"requires": {
-				"debug": "2.6.8",
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.1",
-				"statuses": "1.3.1",
-				"unpipe": "1.0.0"
-			}
+			"integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg=="
 		},
 		"find-cache-dir": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
 			"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-			"requires": {
-				"commondir": "1.0.1",
-				"mkdirp": "0.5.1",
-				"pkg-dir": "1.0.0"
-			}
+			"dev": true
 		},
 		"find-up": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
-			}
+			"dev": true
 		},
 		"flat-cache": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
 			"integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
-			}
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"requires": {
-				"for-in": "1.0.2"
-			}
+			"dev": true
 		},
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -2409,12 +1598,7 @@
 		"form-data": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.16"
-			}
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
 		},
 		"forwarded": {
 			"version": "0.1.0",
@@ -2429,182 +1613,171 @@
 		"from": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
 		},
 		"fs-extra": {
 			"version": "0.26.7",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
 			"integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "2.4.0",
-				"klaw": "1.3.1",
-				"path-is-absolute": "1.0.1",
-				"rimraf": "2.6.1"
-			}
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
 			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"dev": true,
 			"optional": true,
-			"requires": {
-				"nan": "2.6.2",
-				"node-pre-gyp": "0.6.36"
-			},
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
+					"dev": true
 				},
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
-					"requires": {
-						"balanced-match": "0.4.2",
-						"concat-map": "0.0.1"
-					}
+					"dev": true
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2612,107 +1785,87 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
+					"dev": true
 				},
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2720,302 +1873,263 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
+					"dev": true
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
+					"dev": true
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
-					"requires": {
-						"mime-db": "1.27.0"
-					}
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"requires": {
-						"brace-expansion": "1.1.7"
-					}
+					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
+					"dev": true
 				},
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.36",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
+					"dev": true
 				},
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
-					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -3023,98 +2137,58 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
+					"dev": true
 				},
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
+					"dev": true
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -3122,188 +2196,142 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
+					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
+					"dev": true
 				},
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
+					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
+					"dev": true
 				},
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
+					"dev": true,
+					"optional": true
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-			"requires": {
-				"is-property": "1.0.2"
-			}
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
 		},
 		"glob": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
 			"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-			"requires": {
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
-			}
+			"dev": true
 		},
 		"glob-base": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -3311,55 +2339,39 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"requires": {
-				"is-glob": "2.0.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-			"requires": {
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -3367,159 +2379,108 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
 			"integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
-			"requires": {
-				"duplexify": "3.5.1",
-				"infinity-agent": "2.0.3",
-				"is-redirect": "1.0.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.0",
-				"nested-error-stacks": "1.0.2",
-				"object-assign": "3.0.0",
-				"prepend-http": "1.0.4",
-				"read-all-stream": "3.1.0",
-				"timed-out": "2.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"object-assign": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
 				}
 			}
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
-		},
-		"har-schema": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-			"requires": {
-				"ajv": "4.11.8",
-				"har-schema": "1.0.5"
-			}
+			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-			"requires": {
-				"function-bind": "1.1.0"
-			}
+			"dev": true
 		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
 		},
 		"has-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+			"dev": true
 		},
 		"hash-base": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-			"requires": {
-				"inherits": "2.0.3"
-			}
+			"dev": true
 		},
 		"hash.js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
-			}
+			"dev": true
 		},
 		"hawk": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"requires": {
-				"boom": "2.10.1",
-				"cryptiles": "2.0.5",
-				"hoek": "2.16.3",
-				"sntp": "1.0.9"
-			}
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
-			}
-		},
-		"hoek": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
-			}
+			"dev": true
 		},
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
 		},
 		"html-loader": {
 			"version": "0.4.5",
 			"resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.5.tgz",
 			"integrity": "sha1-X7zYfNY6XEmn/OL+VvQl4Fcpxow=",
-			"requires": {
-				"es6-templates": "0.2.3",
-				"fastparse": "1.1.1",
-				"html-minifier": "3.5.3",
-				"loader-utils": "1.1.0",
-				"object-assign": "4.1.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"loader-utils": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"requires": {
-						"big.js": "3.1.3",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -3527,50 +2488,28 @@
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.3.tgz",
 			"integrity": "sha512-iKRzQQDuTCsq0Ultbi/mfJJnR0D3AdZKTq966Gsp92xkmAPCV4Xi08qhJ0Dl3ZAWemSgJ7qZK+UsZc0gFqK6wg==",
-			"requires": {
-				"camel-case": "3.0.0",
-				"clean-css": "4.1.7",
-				"commander": "2.11.0",
-				"he": "1.1.1",
-				"ncname": "1.0.0",
-				"param-case": "2.1.1",
-				"relateurl": "0.2.7",
-				"uglify-js": "3.0.27"
-			}
+			"dev": true
 		},
 		"http-aws-es": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/http-aws-es/-/http-aws-es-1.1.3.tgz",
-			"integrity": "sha1-ZJUYQ7XFETBQclcNfCxQn3gUTWs=",
-			"requires": {
-				"aws-sdk": "2.98.0"
-			}
+			"integrity": "sha1-ZJUYQ7XFETBQclcNfCxQn3gUTWs="
 		},
 		"http-errors": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-			"requires": {
-				"depd": "1.1.1",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.0.3",
-				"statuses": "1.3.1"
-			}
+			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY="
 		},
 		"http-signature": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-			"requires": {
-				"assert-plus": "0.2.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
-			}
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
 		},
 		"https-browserify": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+			"dev": true
 		},
 		"iconv-lite": {
 			"version": "0.4.15",
@@ -3585,12 +2524,14 @@
 		"ignore": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0="
+			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+			"dev": true
 		},
 		"ignore-by-default": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+			"dev": true
 		},
 		"immutable": {
 			"version": "3.8.1",
@@ -3600,74 +2541,55 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"indexof": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+			"dev": true
 		},
 		"infinity-agent": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
-			"integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY="
+			"integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
-			}
+			"dev": true
 		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
-		"ini": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-		},
 		"inquirer": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
 			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-			"requires": {
-				"ansi-escapes": "1.4.0",
-				"ansi-regex": "2.1.1",
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-width": "2.1.0",
-				"figures": "1.7.0",
-				"lodash": "4.17.4",
-				"readline2": "1.0.1",
-				"run-async": "0.1.0",
-				"rx-lite": "3.1.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"through": "2.3.8"
-			}
+			"dev": true
 		},
 		"interpret": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-			"requires": {
-				"loose-envify": "1.3.1"
-			}
+			"dev": true
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"ipaddr.js": {
 			"version": "1.4.0",
@@ -3677,176 +2599,164 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"requires": {
-				"binary-extensions": "1.10.0"
-			}
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"requires": {
-				"builtin-modules": "1.1.1"
-			}
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"requires": {
-				"is-primitive": "2.0.0"
-			}
+			"dev": true
 		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
+			"dev": true
 		},
 		"is-glob": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-			"requires": {
-				"is-extglob": "2.1.1"
-			}
+			"dev": true
 		},
 		"is-my-json-valid": {
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
 			"integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
-			}
+			"dev": true
 		},
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"dev": true
 		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"requires": {
-				"kind-of": "3.2.2"
-			}
+			"dev": true
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-			"requires": {
-				"is-path-inside": "1.0.0"
-			}
+			"dev": true
 		},
 		"is-path-inside": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-			"requires": {
-				"path-is-inside": "1.0.2"
-			}
+			"dev": true
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
 		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"requires": {
-				"has": "1.0.1"
-			}
+			"dev": true
 		},
 		"is-resolvable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
 			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-			"requires": {
-				"tryit": "1.0.3"
-			}
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -3856,7 +2766,8 @@
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -3867,9 +2778,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -3884,45 +2793,31 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-			"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
-			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "4.0.0"
-			}
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"optional": true
+			"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww=="
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-loader": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -3932,140 +2827,98 @@
 		"json3": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsonfile": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-			"requires": {
-				"graceful-fs": "4.1.11"
-			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"dev": true
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
 		},
 		"jsx-ast-utils": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"requires": {
-				"is-buffer": "1.1.5"
-			}
+			"dev": true
 		},
 		"klaw": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-			"requires": {
-				"graceful-fs": "4.1.11"
-			}
+			"dev": true
 		},
 		"latest-version": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
 			"integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
-			"requires": {
-				"package-json": "1.2.0"
-			}
+			"dev": true
 		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"requires": {
-				"invert-kv": "1.0.0"
-			}
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
-			}
+			"dev": true
 		},
 		"load-json-file": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"strip-bom": "3.0.0"
-			}
+			"dev": true
 		},
 		"loader-runner": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+			"dev": true
 		},
 		"loader-utils": {
 			"version": "0.2.17",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-			"requires": {
-				"big.js": "3.1.3",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1",
-				"object-assign": "4.1.1"
-			}
+			"dev": true
 		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
@@ -4078,84 +2931,73 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
-			}
+			"dev": true
 		},
 		"lodash._basecopy": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
 		},
 		"lodash._basecreate": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+			"dev": true
 		},
 		"lodash._bindcallback": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+			"dev": true
 		},
 		"lodash._createassigner": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
 			"integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-			"requires": {
-				"lodash._bindcallback": "3.0.1",
-				"lodash._isiterateecall": "3.0.9",
-				"lodash.restparam": "3.6.1"
-			}
+			"dev": true
 		},
 		"lodash._getnative": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
 		},
 		"lodash._isiterateecall": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
 		},
 		"lodash.cond": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+			"dev": true
 		},
 		"lodash.create": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
 			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._basecreate": "3.0.3",
-				"lodash._isiterateecall": "3.0.9"
-			}
+			"dev": true
 		},
 		"lodash.defaults": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
 			"integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
-			"requires": {
-				"lodash.assign": "3.2.0",
-				"lodash.restparam": "3.6.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"lodash.assign": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
 					"integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-					"requires": {
-						"lodash._baseassign": "3.2.0",
-						"lodash._createassigner": "3.1.1",
-						"lodash.keys": "3.1.2"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -4167,12 +3009,14 @@
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
 		},
 		"lodash.isarray": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
 		},
 		"lodash.isempty": {
 			"version": "4.4.0",
@@ -4183,16 +3027,13 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
-			}
+			"dev": true
 		},
 		"lodash.restparam": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
 		},
 		"lodash.trimend": {
 			"version": "4.5.1",
@@ -4202,66 +3043,58 @@
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"requires": {
-				"js-tokens": "3.0.2"
-			}
+			"dev": true
 		},
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+			"dev": true
 		},
 		"lowercase-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+			"dev": true
 		},
 		"map-stream": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
 		},
 		"markdown-loader": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-2.0.1.tgz",
-			"integrity": "sha1-7ti+rYKXi6zxe3ahHFWToBPi2XY=",
-			"requires": {
-				"loader-utils": "1.1.0",
-				"marked": "0.3.6"
-			},
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-2.0.2.tgz",
+			"integrity": "sha512-v/ej7DflZbb6t//3Yu9vg0T+sun+Q9EoqggifeyABKfvFROqPwwwpv+hd1NKT2QxTRg6VCFk10IIJcMI13yCoQ==",
+			"dev": true,
 			"dependencies": {
 				"loader-utils": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"requires": {
-						"big.js": "3.1.3",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1"
-					}
+					"dev": true
+				},
+				"marked": {
+					"version": "0.3.12",
+					"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+					"integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+					"dev": true
 				}
 			}
-		},
-		"marked": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-			"integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
 		},
 		"md5": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
 			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-			"requires": {
-				"charenc": "0.0.2",
-				"crypt": "0.0.2",
-				"is-buffer": "1.1.5"
-			}
+			"dev": true
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -4272,10 +3105,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"requires": {
-				"errno": "0.1.4",
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"merge-descriptors": {
 			"version": "1.0.1",
@@ -4291,34 +3121,19 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.3"
-			},
+			"dev": true,
 			"dependencies": {
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -4326,10 +3141,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
 			"integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
-			}
+			"dev": true
 		},
 		"mime": {
 			"version": "1.3.4",
@@ -4344,88 +3156,55 @@
 		"mime-types": {
 			"version": "2.1.16",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
-			"requires": {
-				"mime-db": "1.29.0"
-			}
+			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+			"dev": true
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"requires": {
-				"brace-expansion": "1.1.8"
-			}
-		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"requires": {
-				"minimist": "0.0.8"
-			}
+			"dev": true
 		},
 		"mocha": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
 			"integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
-			"requires": {
-				"browser-stdout": "1.3.0",
-				"commander": "2.9.0",
-				"debug": "2.6.8",
-				"diff": "3.2.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.1",
-				"growl": "1.9.2",
-				"json3": "3.3.2",
-				"lodash.create": "3.1.1",
-				"mkdirp": "0.5.1",
-				"supports-color": "3.1.2"
-			},
+			"dev": true,
 			"dependencies": {
 				"commander": {
 					"version": "2.9.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"requires": {
-						"graceful-readlink": "1.0.1"
-					}
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
 					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
 					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -4433,57 +3212,31 @@
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.13.0.tgz",
 			"integrity": "sha1-Aw24xTCyRGZyU7A4YdTNM29+Vsg=",
-			"requires": {
-				"debug": "2.6.8",
-				"md5": "2.2.1",
-				"mkdirp": "0.5.1",
-				"xml": "1.0.1"
-			}
+			"dev": true
 		},
 		"mocha-webpack": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/mocha-webpack/-/mocha-webpack-0.7.0.tgz",
 			"integrity": "sha1-065ax93PKc+UfosO7Xc/pCKODM4=",
-			"requires": {
-				"anymatch": "1.3.2",
-				"fs-extra": "0.30.0",
-				"glob-parent": "2.0.0",
-				"interpret": "1.0.3",
-				"invariant": "2.2.2",
-				"is-glob": "2.0.1",
-				"loader-utils": "0.2.17",
-				"lodash": "4.17.4",
-				"normalize-path": "2.1.1",
-				"object-hash": "1.1.8",
-				"webpack-info-plugin": "0.1.0",
-				"webpack-sources": "0.1.5",
-				"yargs": "4.8.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"fs-extra": {
 					"version": "0.30.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
 					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "2.4.0",
-						"klaw": "1.3.1",
-						"path-is-absolute": "1.0.1",
-						"rimraf": "2.6.1"
-					}
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -4495,26 +3248,27 @@
 		"mute-stream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
 			"integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"ncname": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
 			"integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-			"requires": {
-				"xml-char-classes": "1.0.0"
-			}
+			"dev": true
 		},
 		"negotiator": {
 			"version": "0.6.1",
@@ -4525,86 +3279,43 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
 			"integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
-			"requires": {
-				"inherits": "2.0.3"
-			}
+			"dev": true
 		},
 		"no-case": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
 			"integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-			"requires": {
-				"lower-case": "1.1.4"
-			}
+			"dev": true
 		},
 		"node-dir": {
 			"version": "0.1.17",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
 			"integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-			"requires": {
-				"minimatch": "3.0.4"
-			}
+			"dev": true
 		},
 		"node-libs-browser": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
 			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
-			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.1.4",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
-				"domain-browser": "1.1.7",
-				"events": "1.1.1",
-				"https-browserify": "0.0.1",
-				"os-browserify": "0.2.1",
-				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.3.2",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.3",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
-				"timers-browserify": "2.0.4",
-				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
-				"vm-browserify": "0.0.4"
-			},
+			"dev": true,
 			"dependencies": {
 				"crypto-browserify": {
 					"version": "3.11.1",
 					"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
 					"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
-					"requires": {
-						"browserify-cipher": "1.0.0",
-						"browserify-sign": "4.0.4",
-						"create-ecdh": "4.0.0",
-						"create-hash": "1.1.3",
-						"create-hmac": "1.1.6",
-						"diffie-hellman": "5.0.2",
-						"inherits": "2.0.3",
-						"pbkdf2": "3.0.13",
-						"public-encrypt": "4.0.0",
-						"randombytes": "2.0.5"
-					}
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				},
 				"url": {
 					"version": "0.11.0",
 					"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 					"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-					"requires": {
-						"punycode": "1.3.2",
-						"querystring": "0.2.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -4612,50 +3323,31 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.11.0.tgz",
 			"integrity": "sha1-ImxWK9KnsT09dRi0mtSCijYj0Gw=",
-			"requires": {
-				"chokidar": "1.7.0",
-				"debug": "2.6.8",
-				"es6-promise": "3.3.1",
-				"ignore-by-default": "1.0.1",
-				"lodash.defaults": "3.1.2",
-				"minimatch": "3.0.4",
-				"ps-tree": "1.1.0",
-				"touch": "1.0.0",
-				"undefsafe": "0.0.3",
-				"update-notifier": "0.5.0"
-			}
+			"dev": true
 		},
 		"nopt": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
 			"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-			"requires": {
-				"abbrev": "1.1.0"
-			}
+			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
-			}
+			"dev": true
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"requires": {
-				"remove-trailing-separator": "1.0.2"
-			}
+			"dev": true
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
@@ -4670,39 +3362,31 @@
 		"object-hash": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
-			"integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw="
+			"integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
 			"integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-			"requires": {
-				"define-properties": "1.1.2",
-				"function-bind": "1.1.0",
-				"object-keys": "1.0.11"
-			}
+			"dev": true
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
-			}
+			"dev": true
 		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
 		},
 		"on-headers": {
 			"version": "1.0.1",
@@ -4713,130 +3397,103 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1.0.2"
-			}
+			"dev": true
 		},
 		"onetime": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+			"dev": true
 		},
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
-			}
+			"dev": true
 		},
 		"os-browserify": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+			"dev": true
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"requires": {
-				"lcid": "1.0.0"
-			}
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 			"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
-			}
+			"dev": true
 		},
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"requires": {
-				"p-limit": "1.1.0"
-			}
+			"dev": true
 		},
 		"package-json": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
 			"integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
-			"requires": {
-				"got": "3.3.1",
-				"registry-url": "3.1.0"
-			}
+			"dev": true
 		},
 		"pako": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+			"dev": true
 		},
 		"param-case": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-			"requires": {
-				"no-case": "2.3.1"
-			}
+			"dev": true
 		},
 		"parse-asn1": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-			"requires": {
-				"asn1.js": "4.9.1",
-				"browserify-aes": "1.0.6",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.0",
-				"pbkdf2": "3.0.13"
-			}
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -4844,9 +3501,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"requires": {
-				"error-ex": "1.3.1"
-			}
+			"dev": true
 		},
 		"parseurl": {
 			"version": "1.3.1",
@@ -4856,30 +3511,32 @@
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-			"requires": {
-				"pinkie-promise": "2.0.1"
-			}
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -4890,29 +3547,19 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-			"requires": {
-				"pify": "2.3.0"
-			}
+			"dev": true
 		},
 		"pause-stream": {
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"requires": {
-				"through": "2.3.8"
-			}
+			"dev": true
 		},
 		"pbkdf2": {
 			"version": "3.0.13",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
 			"integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
-			"requires": {
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.8"
-			}
+			"dev": true
 		},
 		"performance-now": {
 			"version": "0.2.0",
@@ -4922,102 +3569,97 @@
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"requires": {
-				"pinkie": "2.0.4"
-			}
+			"dev": true
 		},
 		"pkg-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-			"requires": {
-				"find-up": "1.1.2"
-			}
+			"dev": true
 		},
 		"pluralize": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
 		},
 		"private": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+			"dev": true
 		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"dev": true
 		},
 		"progress": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true
 		},
 		"proxy-addr": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-			"integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
-			"requires": {
-				"forwarded": "0.1.0",
-				"ipaddr.js": "1.4.0"
-			}
+			"integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg="
 		},
 		"prr": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+			"dev": true
 		},
 		"ps-tree": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
 			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-			"requires": {
-				"event-stream": "3.3.4"
-			}
+			"dev": true
 		},
 		"public-encrypt": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"parse-asn1": "5.1.0",
-				"randombytes": "2.0.5"
-			}
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.3.2",
@@ -5037,32 +3679,26 @@
 		"querystring-es3": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"is-number": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
+					"dev": true,
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.5"
-							}
+							"dev": true
 						}
 					}
 				},
@@ -5070,9 +3706,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"requires": {
-						"is-buffer": "1.1.5"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -5080,9 +3714,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
+			"dev": true
 		},
 		"range-parser": {
 			"version": "1.2.0",
@@ -5092,23 +3724,13 @@
 		"raw-body": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-			"integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
-			"requires": {
-				"bytes": "2.4.0",
-				"iconv-lite": "0.4.15",
-				"unpipe": "1.0.0"
-			}
+			"integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y="
 		},
 		"rc": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
 			"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.4",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
@@ -5121,37 +3743,25 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
 			"integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-			"requires": {
-				"pinkie-promise": "2.0.1",
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"read-pkg": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-			"requires": {
-				"load-json-file": "2.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "2.0.0"
-			}
+			"dev": true
 		},
 		"read-pkg-up": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "2.0.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "2.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -5159,52 +3769,31 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
-			}
+			"dev": true
 		},
 		"readdirp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
-				"set-immediate-shim": "1.0.1"
-			}
+			"dev": true
 		},
 		"readline2": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"mute-stream": "0.0.5"
-			}
+			"dev": true
 		},
 		"recast": {
 			"version": "0.11.23",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
 			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-			"requires": {
-				"ast-types": "0.9.6",
-				"esprima": "3.1.3",
-				"private": "0.1.7",
-				"source-map": "0.5.6"
-			},
+			"dev": true,
 			"dependencies": {
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
 				}
 			}
 		},
@@ -5212,14 +3801,13 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"requires": {
-				"resolve": "1.4.0"
-			}
+			"dev": true
 		},
 		"regenerate": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.10.5",
@@ -5230,203 +3818,143 @@
 			"version": "0.9.11",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"private": "0.1.7"
-			}
+			"dev": true
 		},
 		"regex-cache": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-			"requires": {
-				"is-equal-shallow": "0.1.3",
-				"is-primitive": "2.0.0"
-			}
+			"dev": true
 		},
 		"regexpu-core": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"requires": {
-				"regenerate": "1.3.2",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
-			}
+			"dev": true
 		},
 		"registry-url": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"requires": {
-				"rc": "1.2.1"
-			}
+			"dev": true
 		},
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"requires": {
-				"jsesc": "0.5.0"
-			},
+			"dev": true,
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"requires": {
-				"is-finite": "1.0.2"
-			}
+			"dev": true
 		},
 		"request": {
 			"version": "2.81.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-			"requires": {
-				"aws-sign2": "0.6.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.1.4",
-				"har-validator": "4.2.1",
-				"hawk": "3.1.3",
-				"http-signature": "1.1.1",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.16",
-				"oauth-sign": "0.8.2",
-				"performance-now": "0.2.0",
-				"qs": "6.4.0",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.2",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.0.1"
-			}
+			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
 		},
 		"request-promise-core": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-			"requires": {
-				"lodash": "4.17.4"
-			}
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY="
 		},
 		"request-promise-native": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.4.tgz",
-			"integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU=",
-			"requires": {
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.2"
-			}
+			"integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU="
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
-			}
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
 			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
+			"dev": true
 		},
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-			"requires": {
-				"exit-hook": "1.1.1",
-				"onetime": "1.1.0"
-			}
+			"dev": true
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"requires": {
-				"align-text": "0.1.4"
-			}
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-			"requires": {
-				"glob": "7.1.2"
-			},
+			"dev": true,
 			"dependencies": {
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
 				}
 			}
 		},
@@ -5434,23 +3962,19 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-			"requires": {
-				"hash-base": "2.0.2",
-				"inherits": "2.0.3"
-			}
+			"dev": true
 		},
 		"run-async": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-			"requires": {
-				"once": "1.4.0"
-			}
+			"dev": true
 		},
 		"rx-lite": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -5465,61 +3989,42 @@
 		"semver": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"dev": true
 		},
 		"semver-diff": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-			"requires": {
-				"semver": "5.4.1"
-			}
+			"dev": true
 		},
 		"send": {
 			"version": "0.15.4",
 			"resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-			"integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
-			"requires": {
-				"debug": "2.6.8",
-				"depd": "1.1.1",
-				"destroy": "1.0.4",
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"etag": "1.8.0",
-				"fresh": "0.5.0",
-				"http-errors": "1.6.2",
-				"mime": "1.3.4",
-				"ms": "2.0.0",
-				"on-finished": "2.3.0",
-				"range-parser": "1.2.0",
-				"statuses": "1.3.1"
-			}
+			"integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk="
 		},
 		"serve-static": {
 			"version": "1.12.4",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-			"integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
-			"requires": {
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"parseurl": "1.3.1",
-				"send": "0.15.4"
-			}
+			"integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"setprototypeof": {
 			"version": "1.0.3",
@@ -5530,128 +4035,86 @@
 			"version": "2.4.8",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
 			"integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-			"requires": {
-				"inherits": "2.0.3"
-			}
+			"dev": true
 		},
 		"shelljs": {
 			"version": "0.7.8",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.0.3",
-				"rechoir": "0.6.2"
-			},
+			"dev": true,
 			"dependencies": {
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
+					"dev": true
 				}
 			}
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+			"dev": true
 		},
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-		},
-		"sntp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"requires": {
-				"hoek": "2.16.3"
-			}
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"dev": true
 		},
 		"source-list-map": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
-			"integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY="
+			"integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.15",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
 			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-			"requires": {
-				"source-map": "0.5.6"
-			}
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-			"requires": {
-				"spdx-license-ids": "1.2.2"
-			}
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
 		},
 		"split": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
 			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-			"requires": {
-				"through": "2.3.8"
-			}
+			"dev": true
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-		},
-		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
 		},
 		"statuses": {
 			"version": "1.3.1",
@@ -5667,61 +4130,43 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
-			}
+			"dev": true
 		},
 		"stream-combiner": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
 			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-			"requires": {
-				"duplexer": "0.1.1"
-			}
+			"dev": true
 		},
 		"stream-http": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
 			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
-			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
-			}
+			"dev": true
 		},
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
+			"dev": true
 		},
 		"string-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
 			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-			"requires": {
-				"strip-ansi": "3.0.1"
-			}
+			"dev": true
 		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
-			}
+			"dev": true
 		},
 		"stringstream": {
 			"version": "0.0.5",
@@ -5731,20 +4176,19 @@
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
 		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
@@ -5755,97 +4199,86 @@
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
 			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-			"requires": {
-				"ajv": "4.11.8",
-				"ajv-keywords": "1.5.1",
-				"chalk": "1.1.3",
-				"lodash": "4.17.4",
-				"slice-ansi": "0.0.4",
-				"string-width": "2.1.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					}
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
+					"dev": true
 				}
 			}
 		},
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"timed-out": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-			"integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
+			"integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
+			"dev": true
 		},
 		"timers-browserify": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
 			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
-			"requires": {
-				"setimmediate": "1.0.5"
-			}
+			"dev": true
 		},
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"touch": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
 			"integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
-			"requires": {
-				"nopt": "1.0.10"
-			}
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-			"requires": {
-				"punycode": "1.4.1"
-			},
 			"dependencies": {
 				"punycode": {
 					"version": "1.4.1",
@@ -5857,78 +4290,67 @@
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tryit": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+			"dev": true
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"optional": true
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"requires": {
-				"prelude-ls": "1.1.2"
-			}
+			"dev": true
 		},
 		"type-detect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.15",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "2.1.16"
-			}
+			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"uglify-js": {
 			"version": "3.0.27",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
 			"integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
-			"requires": {
-				"commander": "2.11.0",
-				"source-map": "0.5.6"
-			}
+			"dev": true
 		},
 		"uglify-to-browserify": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
 			"optional": true
 		},
 		"undefsafe": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
-			"integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8="
+			"integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -5939,67 +4361,52 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
 			"integrity": "sha1-B7XcIGazYnqztPUwEw9+3doHpMw=",
-			"requires": {
-				"chalk": "1.1.3",
-				"configstore": "1.4.0",
-				"is-npm": "1.0.0",
-				"latest-version": "1.0.1",
-				"repeating": "1.1.3",
-				"semver-diff": "2.1.0",
-				"string-length": "1.0.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"repeating": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
 					"integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-					"requires": {
-						"is-finite": "1.0.2"
-					}
+					"dev": true
 				}
 			}
 		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+			"dev": true
 		},
 		"url": {
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-			"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-			"requires": {
-				"punycode": "1.3.2",
-				"querystring": "0.2.0"
-			}
+			"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ="
 		},
 		"user-home": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-			"requires": {
-				"os-homedir": "1.0.2"
-			}
+			"dev": true
 		},
 		"util": {
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-			"requires": {
-				"inherits": "2.0.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
 				}
 			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"utils-merge": {
 			"version": "1.0.0",
@@ -6015,10 +4422,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
-			}
+			"dev": true
 		},
 		"validator": {
 			"version": "6.2.1",
@@ -6030,166 +4434,89 @@
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
 			"integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
 		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
-		},
 		"vm-browserify": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"requires": {
-				"indexof": "0.0.1"
-			}
+			"dev": true
 		},
 		"watchpack": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
-			"requires": {
-				"async": "2.5.0",
-				"chokidar": "1.7.0",
-				"graceful-fs": "4.1.11"
-			}
+			"dev": true
 		},
 		"webpack": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
-			"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
-			"requires": {
-				"acorn": "5.1.1",
-				"acorn-dynamic-import": "2.0.2",
-				"ajv": "4.11.8",
-				"ajv-keywords": "1.5.1",
-				"async": "2.5.0",
-				"enhanced-resolve": "3.4.1",
-				"interpret": "1.0.3",
-				"json-loader": "0.5.7",
-				"json5": "0.5.1",
-				"loader-runner": "2.3.0",
-				"loader-utils": "0.2.17",
-				"memory-fs": "0.4.1",
-				"mkdirp": "0.5.1",
-				"node-libs-browser": "2.0.0",
-				"source-map": "0.5.6",
-				"supports-color": "3.2.3",
-				"tapable": "0.2.8",
-				"uglify-js": "2.8.29",
-				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
-				"yargs": "6.6.0"
-			},
+			"integrity": "sha1-sqEiaAQ3P/09A+qca9UlBnA09rE=",
+			"dev": true,
 			"dependencies": {
 				"camelcase": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true
 				},
 				"cliui": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
-						"wordwrap": "0.0.2"
-					}
+					"dev": true
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
+					"dev": true
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
+					"dev": true
 				},
 				"source-list-map": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-					"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+					"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-					"requires": {
-						"source-map": "0.5.6",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
-					},
+					"dev": true,
 					"dependencies": {
 						"yargs": {
 							"version": "3.10.0",
 							"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
-								"window-size": "0.1.0"
-							}
+							"dev": true
 						}
 					}
 				},
@@ -6197,55 +4524,37 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
 					"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
-					"requires": {
-						"source-list-map": "2.0.0",
-						"source-map": "0.5.6"
-					}
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+					"dev": true
 				},
 				"wordwrap": {
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true
 				},
 				"yargs": {
 					"version": "6.6.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
-					},
+					"dev": true,
 					"dependencies": {
 						"camelcase": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
 							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1",
-								"wrap-ansi": "2.1.0"
-							}
+							"dev": true
 						}
 					}
 				},
@@ -6253,14 +4562,13 @@
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "3.0.0"
-					},
+					"dev": true,
 					"dependencies": {
 						"camelcase": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+							"dev": true
 						}
 					}
 				}
@@ -6270,180 +4578,125 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-info-plugin/-/webpack-info-plugin-0.1.0.tgz",
 			"integrity": "sha1-3/56qI/LlsWcxFCXZCHq+YzbeQE=",
-			"requires": {
-				"chalk": "1.1.3"
-			}
+			"dev": true
 		},
 		"webpack-sources": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
 			"integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-			"requires": {
-				"source-list-map": "0.1.8",
-				"source-map": "0.5.6"
-			}
+			"dev": true
 		},
 		"which-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+			"dev": true
 		},
 		"window-size": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+			"dev": true
 		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-			"requires": {
-				"mkdirp": "0.5.1"
-			}
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"slide": "1.1.6"
-			}
+			"dev": true
 		},
 		"xdg-basedir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
 			"integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-			"requires": {
-				"os-homedir": "1.0.2"
-			}
+			"dev": true
 		},
 		"xml": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-			"integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+			"integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+			"dev": true
 		},
 		"xml-char-classes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
-			"integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
+			"integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
+			"dev": true
 		},
 		"xml2js": {
 			"version": "0.4.17",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-			"integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-			"requires": {
-				"sax": "1.2.1",
-				"xmlbuilder": "4.2.1"
-			}
+			"integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
 		},
 		"xmlbuilder": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-			"integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-			"requires": {
-				"lodash": "4.17.4"
-			}
+			"integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
 		},
 		"yargs": {
 			"version": "4.8.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 			"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-			"requires": {
-				"cliui": "3.2.0",
-				"decamelize": "1.2.0",
-				"get-caller-file": "1.0.2",
-				"lodash.assign": "4.2.0",
-				"os-locale": "1.4.0",
-				"read-pkg-up": "1.0.1",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "1.0.2",
-				"which-module": "1.0.0",
-				"window-size": "0.2.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "2.4.1"
-			},
+			"dev": true,
 			"dependencies": {
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
+					"dev": true
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
+					"dev": true
 				}
 			}
 		},
@@ -6451,10 +4704,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-			"requires": {
-				"camelcase": "3.0.0",
-				"lodash.assign": "4.2.0"
-			}
+			"dev": true
 		}
 	}
 }

--- a/gibs-ops-api/package.json
+++ b/gibs-ops-api/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "expect.js": "^0.3.1",
     "html-loader": "^0.4.5",
-    "markdown-loader": "^2.0.0",
+    "markdown-loader": "^2.0.2",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",
     "mocha-webpack": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Cumulus Framework for ingesting and processing Nasa Earth data streams",
   "scripts": {
     "test": "lerna run test",
+    "bootstrap": "lerna bootstrap",
     "ybootstrap": "lerna bootstrap --npm-client=yarn",
     "clean": "lerna clean",
     "build": "lerna run --parallel --no-sort build",


### PR DESCRIPTION
[CUMULUS-247] Resolve vulnerability in marked npm module.

This PR addresses:
* Security vulnerability for `marked` a dependency of `markdown-loader` in the `gibs-ops-api`
* Reverting removal of the `bootstrap` command from `package.json`

_Why so many changes to `gibs-ops-api/package-lock.json`?_
When running `npm install` in the `gibs-ops-api`, it didn't update the `marked` dependency (or make any changes at all. It looks like this may be an issue with [node version 6.10](https://stackoverflow.com/questions/45866533/npm-install-not-create-a-new-package-lock-json). I updated package-lock.json by using node 8.0.0 and running npm install. This made a bunch of unrelated updates.

https://bugs.earthdata.nasa.gov/browse/CUMULUS-247
  