### PR TITLE
Fix set message adapter version

### DIFF
--- a/cumulus/services/sfn-scheduler/package.json
+++ b/cumulus/services/sfn-scheduler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/sfn-scheduler",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Runs ingest timers as configured in /config/products.json",
   "main": "index.js",
   "keywords": [
@@ -17,7 +17,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "lodash": "^4.17.4",
     "uuid": "^3.0.1"
   }

--- a/cumulus/tasks/delete-pdr-ftp/package.json
+++ b/cumulus/tasks/delete-pdr-ftp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/delete-pdr-ftp",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler PDR discovery task",
   "main": "index.js",
   "keywords": [
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/delete-pdr-s3/package.json
+++ b/cumulus/tasks/delete-pdr-s3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/delete-pdr-s3",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler PDR discovery task",
   "main": "index.js",
   "keywords": [
@@ -39,7 +39,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/discover-cmr-granules/package.json
+++ b/cumulus/tasks/discover-cmr-granules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/discover-cmr-granules",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Discovers granules from the CMR",
   "main": "index.js",
   "keywords": [
@@ -14,7 +14,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1"
   }

--- a/cumulus/tasks/discover-granules/package.json
+++ b/cumulus/tasks/discover-granules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/discover-granules",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Discover Granules in FTP/HTTP/SFTP endpoints",
   "main": "index.js",
   "directories": {
@@ -38,10 +38,10 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/sled": "^1.0.0-beta.14",
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/sled": "^1.0.0-beta.15",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.23.0",

--- a/cumulus/tasks/discover-http-tiles/package.json
+++ b/cumulus/tasks/discover-http-tiles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/discover-http-tiles",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Crawls an HTTP endpoint to discover tiled imagery",
   "main": "index.js",
   "keywords": [
@@ -14,7 +14,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "async": "^2.0.0",
     "lodash": "^4.15.0",
     "simplecrawler": "git+https://github.com/cgiffard/node-simplecrawler.git#193e506c39164ddf045c7c6c502e1a015d85a290"

--- a/cumulus/tasks/discover-pdr/package.json
+++ b/cumulus/tasks/discover-pdr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/discover-pdr",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler PDR discovery task",
   "main": "index.js",
   "keywords": [
@@ -36,8 +36,8 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/discover-pdrs/package.json
+++ b/cumulus/tasks/discover-pdrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/discover-pdrs",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Discover PDRs in FTP and HTTP endpoints",
   "main": "index.js",
   "directories": {
@@ -37,10 +37,10 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "@cumulus/cumulus-message-adapter-js": "~0.0.1-beta.2",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.23.0",

--- a/cumulus/tasks/discover-s3-granules/package.json
+++ b/cumulus/tasks/discover-s3-granules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/discover-s3-granules",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Discover granules from an S3 bucket",
   "main": "index.js",
   "directories": {
@@ -35,8 +35,8 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.23.0",

--- a/cumulus/tasks/download-activity-mock/package.json
+++ b/cumulus/tasks/download-activity-mock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/dowload-activity-mock",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Mock for provider gateway",
   "main": "index.js",
   "keywords": [
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/filter-payload/package.json
+++ b/cumulus/tasks/filter-payload/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/filter-payload",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Task to filter the payload from one task to the next",
   "main": "index.js",
   "keywords": [
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14"
+    "@cumulus/common": "^1.0.0-beta.15"
   },
   "devDependencies": {
     "@ava/babel-preset-stage-4": "^1.1.0",

--- a/cumulus/tasks/generate-mrf/package.json
+++ b/cumulus/tasks/generate-mrf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/generate-mrf",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Generates MRFs for ingested tiles",
   "main": "index.js",
   "keywords": [
@@ -14,7 +14,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "async": "^2.0.0",
     "lodash": "^4.13.1",
     "mustache": "^2.2.1",

--- a/cumulus/tasks/generate-pan/package.json
+++ b/cumulus/tasks/generate-pan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/generate-pan",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler PAN generation/upload task",
   "main": "index.js",
   "keywords": [
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/generate-pdr-file-list/package.json
+++ b/cumulus/tasks/generate-pdr-file-list/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/generate-pdr-file-list",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler PDR processing task",
   "main": "index.js",
   "keywords": [
@@ -35,9 +35,9 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/pvl": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/pvl": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/generate-pdrd/package.json
+++ b/cumulus/tasks/generate-pdrd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/generate-pdrd",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler generating a PDRD when PDR validation fails",
   "main": "index.js",
   "keywords": [
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/hello-world/package.json
+++ b/cumulus/tasks/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/hello-world",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Example task",
   "main": "index.js",
   "directories": {
@@ -37,7 +37,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/cumulus/tasks/parse-pdr/package.json
+++ b/cumulus/tasks/parse-pdr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/parse-pdr",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Download and Parse a given PDR",
   "main": "index.js",
   "directories": {
@@ -40,10 +40,10 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "@cumulus/cumulus-message-adapter-js": "0.0.1-beta.2",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/cumulus/tasks/pdr-status-check/package.json
+++ b/cumulus/tasks/pdr-status-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/pdr-status-check",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Checks execution status of granules in a PDR",
   "main": "index.js",
   "directories": {
@@ -38,9 +38,9 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/cumulus/tasks/post-to-cmr/package.json
+++ b/cumulus/tasks/post-to-cmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/post-to-cmr",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Post a given granule to CMR",
   "main": "index.js",
   "directories": {
@@ -38,10 +38,10 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/cmrjs": "^1.0.0-beta.14",
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/cmrjs": "^1.0.0-beta.15",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/cumulus/tasks/queue-granules/package.json
+++ b/cumulus/tasks/queue-granules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/queue-granules",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Add discovered granules to the queue",
   "main": "index.js",
   "directories": {
@@ -38,8 +38,8 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/cumulus/tasks/queue-pdrs/package.json
+++ b/cumulus/tasks/queue-pdrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/queue-pdrs",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Add discovered PDRs to a queue",
   "main": "index.js",
   "directories": {
@@ -37,8 +37,8 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/cumulus/tasks/run-gdal/package.json
+++ b/cumulus/tasks/run-gdal/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@cumulus/run-gdal",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Runs gdal commands as a task",
   "main": "index.js",
   "keywords": [
@@ -29,6 +29,6 @@
     "webpack": "^1.12.13"
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14"
+    "@cumulus/common": "^1.0.0-beta.15"
   }
 }

--- a/cumulus/tasks/sync-granule/package.json
+++ b/cumulus/tasks/sync-granule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/sync-granule",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Download a given granule",
   "main": "index.js",
   "directories": {
@@ -41,9 +41,9 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.23.0",

--- a/cumulus/tasks/sync-http-urls/package.json
+++ b/cumulus/tasks/sync-http-urls/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/sync-http-urls",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Synchronizes http links to s3",
   "main": "index.js",
   "keywords": [
@@ -14,7 +14,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "async": "^2.0.0",
     "lodash": "^4.13.1",
     "request": "^2.83.0"

--- a/cumulus/tasks/sync-wms/package.json
+++ b/cumulus/tasks/sync-wms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/sync-wms",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Transforms input granule info to WMS URLs for URL sync",
   "main": "index.js",
   "keywords": [
@@ -14,6 +14,6 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14"
+    "@cumulus/common": "^1.0.0-beta.15"
   }
 }

--- a/cumulus/tasks/tee/package.json
+++ b/cumulus/tasks/tee/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/tee",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Task for testing that splits output",
   "main": "index.js",
   "keywords": [
@@ -15,7 +15,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/cumulus/tasks/trigger-ingest/package.json
+++ b/cumulus/tasks/trigger-ingest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/trigger-ingest",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Transforms input granule info to WMS URLs for URL sync",
   "main": "index.js",
   "keywords": [
@@ -14,6 +14,6 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14"
+    "@cumulus/common": "^1.0.0-beta.15"
   }
 }

--- a/cumulus/tasks/trigger-mrf-gen/package.json
+++ b/cumulus/tasks/trigger-mrf-gen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/trigger-mrf-gen",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Invokes MRFGen for every group of images passed to it",
   "main": "index.js",
   "keywords": [
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14"
+    "@cumulus/common": "^1.0.0-beta.15"
   },
   "devDependencies": {
     "@ava/babel-preset-stage-4": "^1.1.0",

--- a/cumulus/tasks/trigger-process-pdrs/package.json
+++ b/cumulus/tasks/trigger-process-pdrs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/trigger-process-pdrs",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Transforms input granule info to WMS URLs for URL sync",
   "main": "index.js",
   "keywords": [
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14"
+    "@cumulus/common": "^1.0.0-beta.15"
   },
   "devDependencies": {
     "@ava/babel-preset-stage-4": "^1.1.0",

--- a/cumulus/tasks/validate-archives/package.json
+++ b/cumulus/tasks/validate-archives/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/validate-archives",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler archive validation task",
   "main": "index.js",
   "keywords": [
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "checksum": "^0.1.1",
     "ftp": "^0.3.10",
     "gunzip-maybe": "^1.4.1",

--- a/cumulus/tasks/validate-pdr/package.json
+++ b/cumulus/tasks/validate-pdr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/validate-pdr",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SIPS handler PDR processing task",
   "main": "index.js",
   "keywords": [
@@ -39,9 +39,9 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/pvl": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/pvl": "^1.0.0-beta.15",
     "ftp": "^0.3.10",
     "node-fetch": "^1.6.1",
     "parse-duration": "^0.1.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "packages": [
     "packages/*",
     "cumulus/tasks/*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/api",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Lambda functions for handling all daac's API operations",
   "main": "index.js",
   "scripts": {
@@ -24,10 +24,10 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/cmrjs": "^1.0.0-beta.14",
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/ingest": "^1.0.0-beta.14",
-    "@cumulus/pvl": "^1.0.0-beta.14",
+    "@cumulus/cmrjs": "^1.0.0-beta.15",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/ingest": "^1.0.0-beta.15",
+    "@cumulus/pvl": "^1.0.0-beta.15",
     "ajv": "^5.2.2",
     "aws-sdk": "^2.95.0",
     "babel-core": "^6.25.0",

--- a/packages/cmrjs/package.json
+++ b/packages/cmrjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cmrjs",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "A node SDK for CMR",
   "scripts": {
     "test": "echo 'no tests'"
@@ -26,7 +26,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "got": "^7.1.0",
     "json-loader": "^0.5.4",
     "lodash.property": "^4.4.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/common",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Common utilities used across tasks",
   "keywords": [
     "GIBS",
@@ -32,7 +32,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "ajv": "^5.0.4-beta.3",
     "ajv-cli": "^1.1.1",
     "async": "^2.0.0",

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -5,7 +5,6 @@ default:
   urs_url: https://uat.urs.earthdata.nasa.gov
 
   repo_owner: cumulus-nasa
-  message_adapter_version: v0.0.1
   message_adapter_repo: cumulus-message-adapter
   message_adapter_filename: cumulus-message-adapter.zip
 

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/deployment",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Deployment templates for cumulus",
   "scripts": {
     "test": "echo 'no tests'",

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/ingest",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Ingest utilities",
   "scripts": {
     "test": "ava test/*.js"
@@ -37,9 +37,9 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
-    "@cumulus/pvl": "^1.0.0-beta.14",
-    "@cumulus/test-data": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
+    "@cumulus/pvl": "^1.0.0-beta.15",
+    "@cumulus/test-data": "^1.0.0-beta.15",
     "aws-sdk": "^2.4.11",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.2.4",

--- a/packages/pvl/package.json
+++ b/packages/pvl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/pvl",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Parse and serialize Parameter Value Language, a data markup language used by NASA",
   "main": "index.js",
   "scripts": {

--- a/packages/sled/package.json
+++ b/packages/sled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/sled",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Protocol wrapper for Cumulus JS files",
   "main": "index.js",
   "scripts": {

--- a/packages/task-debug/package.json
+++ b/packages/task-debug/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/task-debug",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "A harness for debugging workflows.",
   "main": "index.js",
   "repository": {
@@ -18,7 +18,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@cumulus/common": "^1.0.0-beta.14",
+    "@cumulus/common": "^1.0.0-beta.15",
     "commander": "^2.11.0"
   },
   "devDependencies": {

--- a/packages/test-data/package.json
+++ b/packages/test-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/test-data",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "Includes the test data for various packages",
   "keywords": [
     "GIBS",


### PR DESCRIPTION
Revert addition of `message_adapter_version` to `@cumulus/deployment` config file. This was configuration leftover from adhoc changes made during development of the deployment process. Users of the `@cumulus/deployment` package should set the version themselves in their cumulus deployments if a specific version is required, otherwise @cumulus/deployment will use the latest version by default.

Relevant change can be found below in `packages/deployment/app/config.yml`