### PR TITLE
CUMULUS-302 sf-sns-broadcast does not properly handle '$.error' field

### DIFF
--- a/daac-ops-api/lambdas/sf-sns-broadcast.js
+++ b/daac-ops-api/lambdas/sf-sns-broadcast.js
@@ -35,8 +35,8 @@ async function publish(message, finish = false) {
   }
 
   if (failed) {
-    const error = get(event, 'exception.Error');
-    const cause = get(event, 'exception.Cause');
+    const error = get(event, 'exception.Error', get(event, 'error.Error'));
+    const cause = get(event, 'exception.Cause', get(event, 'error.Cause'));
     if (error) {
       if (errors[error]) {
         throw new errors[error](cause);


### PR DESCRIPTION
We can use lodash.get's default value handling to try the error field as a backup.