### PR TITLE
ensure a discovered file matches both the granuleIdExtraction and collection regexes

### DIFF
--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -72,7 +72,10 @@ class Discover {
         }
       }
 
-      return file;
+      // if collection regex matched, the following will be true
+      if (file.granuleId && file.bucket) {
+        return file;
+      }
     }
     return false;
   }

--- a/packages/ingest/test/granule.js
+++ b/packages/ingest/test/granule.js
@@ -59,3 +59,14 @@ Object.keys(sums).forEach((key) => {
     t.true(validated);
   });
 });
+
+test('filter files using regex', (t) => {
+  const payload = Object.assign({}, discoverPayload);
+  payload.collection.meta.granuleIdExtraction = '^example$';
+  const discover = new HttpDiscoverGranules(discoverPayload);
+  const file = {
+    name: 'example'
+  };
+  const result = discover.setGranuleInfo(file);
+  t.true(result === false);
+});


### PR DESCRIPTION
adds a test and ensures that a file will match both the granuleIdExtraction regex and one of the collection regexes, otherwise `Discover.setGranuleInfo` will return false.