### PR TITLE
Integration tests get lambda output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Expanded @cumulus/deployment test coverage
 - all tasks were updated to use cumulus-message-adapter-js 1.0.1
 - added build process to integration-tests package to babelify it before publication
+- Update @cumulus/integration-tests lambda.js#getLambdaOutput to return the entire lambda output. Previously was returning only the payload.
 
 ## [v1.1.1] - 2018-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Expanded @cumulus/deployment test coverage
 - all tasks were updated to use cumulus-message-adapter-js 1.0.1
 - added build process to integration-tests package to babelify it before publication
-- Update @cumulus/integration-tests lambda.js#getLambdaOutput to return the entire lambda output. Previously was returning only the payload.
+- Update @cumulus/integration-tests lambda.js `getLambdaOutput` to return the entire lambda output. Previously `getLambdaOutput` returned only the payload.
 
 ## [v1.1.1] - 2018-03-08
 

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -158,6 +158,8 @@ async function testWorkflow(stackName, bucketName, workflowName, inputFile) {
   }
 }
 
-exports.testWorkflow = testWorkflow;
-exports.executeWorkflow = executeWorkflow;
-exports.getLambdaOutput = lambda.getLambdaOutputPayload;
+module.exports = {
+  testWorkflow,
+  executeWorkflow,
+  getLambdaOutput: lambda.getLambdaOutput
+};

--- a/packages/integration-tests/lambda.js
+++ b/packages/integration-tests/lambda.js
@@ -68,7 +68,7 @@ async function getLambdaExecution(workflowExecutionArn, lambdaName) {
  * @param {string} lambdaName - name of the lambda
  * @returns {Object} object containing the payload, null if error
  */
-async function getLambdaOutputPayload(workflowExecutionArn, lambdaName) {
+async function getLambdaOutput(workflowExecutionArn, lambdaName) {
   const lambdaExecution = await getLambdaExecution(workflowExecutionArn, lambdaName);
 
   if (lambdaExecution === null) {
@@ -83,7 +83,7 @@ async function getLambdaOutputPayload(workflowExecutionArn, lambdaName) {
   }
 
   const succeededDetails = JSON.parse(lambdaExecution.completeEvent.lambdaFunctionSucceededEventDetails.output.toString());
-  return succeededDetails.payload;
+  return succeededDetails;
 }
 
-exports.getLambdaOutputPayload = getLambdaOutputPayload;
+exports.getLambdaOutput = getLambdaOutput;


### PR DESCRIPTION
**Summary:** @cumulus/integration-tests lambda.js#getLambdaOutput returns entire lambda output, not just he payload.

## Test Plan

- [x] Adhoc testing - tested via `./bin/cli.js workflow --stack-name aimee-deploy-cumulus --bucket-name cumulus-devseed-internal --workflow HelloWorldWorkflow --input-file ./helloWorldInput.json`. This doesn't test this function but it does test it didn't break anything else.
- [x] Update CHANGELOG

I think it is useful to test the full cumulus message in integration tests - I will be using this in cumulus-integration-tests