### PR TITLE
publish only on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,4 +201,4 @@ workflows:
             - build_and_test
           filters:
             branches:
-              only: master
+              only: release 


### PR DESCRIPTION
Update circleci branch flag. This got changed back to master when I was resolving a conflict. This PR will fix it.