### PR TITLE
Increase memory for CustomBootstrapLambdaFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - **CUMULUS-304: "Add AWS API throttling to pdr-status-check task"** Added concurrency limit on SFN API calls.  The default concurrency is 10 and is configurable through Lambda environment variable CONCURRENCY.
+- Increased memory allotment for `CustomBootstrapLambdaFunction`. Resolves failed deployments where `CustomBootstrapLambdaFunction` was failing with error `Process exited before completing request`. This error is thrown when the lambda function tries to use more memory than it is allotted.
 
 ## [v1.2.0] - 2018-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - **CUMULUS-304: "Add AWS API throttling to pdr-status-check task"** Added concurrency limit on SFN API calls.  The default concurrency is 10 and is configurable through Lambda environment variable CONCURRENCY.
-- Increased memory allotment for `CustomBootstrap`. Resolves failed deployments where `CustomBootstrap` was failing with error `Process exited before completing request`. This error is thrown when the lambda function tries to use more memory than it is allotted.
+- Increased memory allotment for `CustomBootstrap` lambda function. Resolves failed deployments where `CustomBootstrap` lambda function was failing with error `Process exited before completing request`. This was causing deployments to stall, fail to update and fail to rollback. This error is thrown when the lambda function tries to use more memory than it is allotted.
 
 ## [v1.2.0] - 2018-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - **CUMULUS-304: "Add AWS API throttling to pdr-status-check task"** Added concurrency limit on SFN API calls.  The default concurrency is 10 and is configurable through Lambda environment variable CONCURRENCY.
-- Increased memory allotment for `CustomBootstrapLambdaFunction`. Resolves failed deployments where `CustomBootstrapLambdaFunction` was failing with error `Process exited before completing request`. This error is thrown when the lambda function tries to use more memory than it is allotted.
+- Increased memory allotment for `CustomBootstrap`. Resolves failed deployments where `CustomBootstrap` was failing with error `Process exited before completing request`. This error is thrown when the lambda function tries to use more memory than it is allotted.
 
 ## [v1.2.0] - 2018-03-20
 

--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -99,7 +99,7 @@ jobs:
 CustomBootstrap:
   handler: index.bootstrap
   timeout: 100
-  memory: 256
+  memory: 1024
   source: 'node_modules/@cumulus/api/dist/'
   envs:
     internal: '{{buckets.internal}}'

--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -99,7 +99,7 @@ jobs:
 CustomBootstrap:
   handler: index.bootstrap
   timeout: 100
-  memory: 1024
+  memory: 512
   source: 'node_modules/@cumulus/api/dist/'
   envs:
     internal: '{{buckets.internal}}'


### PR DESCRIPTION
**Summary:** Increase memory for CustomBootstrapLambdaFunction

## Test Plan

- [x] Successful deployment successful where the same configuration had failed
- [x] Testing an instance of this lambda with 256 MB vs more memory failed with the former amount of memory and succeeded with increased memory limit.

Also, you can see the amount of memory lambda tries to use here:

<img width="1308" alt="screen shot 2018-03-22 at 3 10 10 pm" src="https://user-images.githubusercontent.com/15016780/37792847-4e6c85ec-2de3-11e8-8b51-2b9c8c9c9e9e.png">

