### PR TITLE
fix missing schemas directory in hello-world task

### DIFF
--- a/tasks/hello-world/schemas/output.json
+++ b/tasks/hello-world/schemas/output.json
@@ -1,0 +1,12 @@
+{
+  "title": "HelloWorldOutput",
+  "description": "Describes the output produced by the hello-world task",
+  "type": "object",
+  "required": ["hello"],
+  "additionalProperties": false,
+  "properties": {
+    "hello": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Fixes this issue that came up because of a missing schemas dir:


```
lerna ERR! execute Error occured with '@cumulus/hello-world' while running 'npm run postinstall'
lerna ERR! npm run postinstall [@cumulus/hello-world] Output from stdout:

> @cumulus/hello-world@1.2.0 postinstall /Users/mhuffnagle/Source/cumulus/tasks/hello-world
> npm run build


> @cumulus/hello-world@1.2.0 build /Users/mhuffnagle/Source/cumulus/tasks/hello-world
> rm -rf dist && mkdir dist && cp -R schemas dist/ && webpack --progress


lerna ERR! npm run postinstall [@cumulus/hello-world] Output from stderr:
cp: schemas: No such file or directory
```

This PR also improves the example to show example of using a json schema for validating the output.
