### PR TITLE
use the proper deployment for aws testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,11 @@ jobs:
               # run the yarn link package-name on the integration tests
               cat cumulus_integration_tests_packages.txt | xargs -I % yarn link %
 
+              # copy override config
+              cp ../project/tests/config.override.yml spec
+
               # deploy latest version of the packages to the aws
-              yarn deploy
+              ./node_modules/.bin/kes cf deploy --kes-folder app --region us-east-1 --deployment cumulus-from-source --template node_modules/@cumulus/deployment/app
 
               # run the tests
               yarn test

--- a/tests/config.override.yml
+++ b/tests/config.override.yml
@@ -1,0 +1,23 @@
+stackName: test-source-integration
+bucket: cumulus-test-sandbox-internal
+DiscoverAndQueuePdrs: &defaults
+  meta:
+    stack: test-source-integration
+    buckets:
+      internal: cumulus-test-sandbox-internal
+      private: cumulus-test-sandbox-private
+    templates:
+      ParsePdr: s3://cumulus-test-sandbox-internal/test-source-integration/workflows/ParsePdr.json
+      IngestGranule: s3://cumulus-test-sandbox-internal/test-source-integration/workflows/IngestGranule.json
+    queues:
+      startSF: https://sqs.us-east-1.amazonaws.com/{{AWS_ACCOUNT_ID}}/test-source-integration-startSF
+ParsePdr: *defaults
+IngestGranule:
+  <<: *defaults
+  SyncGranuleOutput:
+    granules:
+      - files:
+        - bucket: cumulus-test-sandbox-private
+          filename: s3://cumulus-test-sandbox-private/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf
+        - bucket: cumulus-test-sandbox-private
+          filename: s3://cumulus-test-sandbox-private/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met


### PR DESCRIPTION
**Summary:** Summary of changes

This PR will make sure that we use the `test-from-source` deployment on aws for integration testing on release branch

## Changes

* use the `test-from-source` deployment on aws for integration testing on release branch
