### PR TITLE
Added filtering of granules within pdr

### DIFF
--- a/tasks/parse-pdr/index.js
+++ b/tasks/parse-pdr/index.js
@@ -36,6 +36,16 @@ function parsePdr(event) {
   return parse.ingest()
     .then((payload) => {
       if (parse.connected) parse.end();
+
+      // opportunity to filter the granules of interest based on regex in granuleIdExtraction
+      const granuleIdExtraction = config.collection.granuleIdExtraction;
+      if (granuleIdExtraction) {
+        const filteredPayload = {
+          granules: payload.granules.filter((g) => g.files[0].name.match(granuleIdExtraction))
+        };
+        return Object.assign({}, event.input, filteredPayload);
+      }
+
       return Object.assign({}, event.input, payload);
     })
     .catch((e) => {


### PR DESCRIPTION
**Summary:** Added filtering of granules within PDR

Addresses [CUMULUS-527](https://bugs.earthdata.nasa.gov/browse/CUMULUS-527)

## Changes

* Added filtering of granules within a PDR based on config.granuleIdExtraction

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
- [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved


Reviewers: @scisco @laurenfrederick 
