### PR TITLE
Fix requirement to create in /tmp for AWS

### DIFF
--- a/packages/common/util.js
+++ b/packages/common/util.js
@@ -7,13 +7,14 @@ const os = require('os');
 /**
  * Synchronously makes a temporary directory, smoothing over the differences between
  * mkdtempSync in node.js for various platforms and versions
+ * 
  * @param {string} name - A base name for the temp dir, to be uniquified for the final name
- * @return - The absolute path to the created dir
+ * @returns {string} - The absolute path to the created dir
  */
 exports.mkdtempSync = (name) => {
-  if (fs.mkdtempSync) {
-    return fs.mkdtempSync(`gitc_${name}`);
-  }
+  // if (fs.mkdtempSync) {
+  //   return fs.mkdtempSync(`gitc_${name}`);
+  // }
   const dirname = ['gitc', name, +new Date()].join('_');
   const abspath = path.join(os.tmpdir(), dirname);
   fs.mkdirSync(abspath, 0o700);


### PR DESCRIPTION
**Summary:** Create in /tmp

Addresses [CUMULUS-525: common.utils.mkdtempSync fails on AWS](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Commented out code to always create in os.tmpDir()

## Test Plan
Things that should succeed before merging.

- [ x] Unit tests
- [x] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved


Reviewers: @scisco @laurenfrederick 