### PR TITLE
Cumulus 471

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- **CUMULUS-470** In-region S3 Policy lambda added to API to update bucket policy for in-region access. 
+- Deployment support to subscribe to an SNS topic that already exists
+- **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to update bucket policy for in-region access. 
 
 ## [v1.5.1] - 2018-04-23
 ### Fixed

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -90,9 +90,6 @@ default:
   # URS users who should have access to the dashboard application.
   users:
     - username: testuser
-    - username: lfrederick
-    - username: kkelly
-    - username: mhuffnagle2
 
 cumulus-from-npm:
   prefix: test-npm # used by the integration repo
@@ -101,42 +98,3 @@ cumulus-from-npm:
 cumulus-from-source:
   prefix: test-src # used by the cumulus repo
   stackNameNoDash: TestSourceIntegration
-
-lf-test:
-  stackName: lf-test-cumulus
-  stackNameNoDash: lfTestCumulus
-
-  es: 
-    elasticSearchMapping: 6
-
-  iams:
-    ecsRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-ecs'
-    lambdaApiGatewayRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-lambda-api-gateway'
-    lambdaProcessingRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-lambda-processing'
-    stepRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-steprole'
-    instanceProfile: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:instance-profile/lf-test-cumulus-ecs'
-
-lf:
-  stackName: lf-cumulus
-  stackNameNoDash: lfCumulus
-
-  es: 
-    elasticSearchMapping: 7
-
-  iams:
-    ecsRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-ecs'
-    lambdaApiGatewayRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-lambda-api-gateway'
-    lambdaProcessingRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-lambda-processing'
-    stepRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-steprole'
-    instanceProfile: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:instance-profile/lf-cumulus-ecs'
-
-lpf:
-  stackName: lpf-cumulus
-  stackNameNoDash: lpfCumulus
-
-  iams:
-    ecsRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-ecs'
-    lambdaApiGatewayRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-lambda-api-gateway'
-    lambdaProcessingRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-lambda-processing'
-    stepRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-steprole'
-    instanceProfile: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:instance-profile/lpf-cumulus-ecs'

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -69,6 +69,15 @@ default:
             array:
               - InRegionS3PolicyLambdaFunction
               - Arn
+    AmazonIpSpaceChanged:
+      arn: arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged
+      subscriptions:
+        lambda:
+          endpoint:
+            function: Fn::GetAtt
+            array:
+              - InRegionS3PolicyLambdaFunction
+              - Arn
 
   urs_url: https://uat.urs.earthdata.nasa.gov/ #make sure to include the trailing slash
 
@@ -81,6 +90,9 @@ default:
   # URS users who should have access to the dashboard application.
   users:
     - username: testuser
+    - username: lfrederick
+    - username: kkelly
+    - username: mhuffnagle2
 
 cumulus-from-npm:
   prefix: test-npm # used by the integration repo
@@ -89,3 +101,42 @@ cumulus-from-npm:
 cumulus-from-source:
   prefix: test-src # used by the cumulus repo
   stackNameNoDash: TestSourceIntegration
+
+lf-test:
+  stackName: lf-test-cumulus
+  stackNameNoDash: lfTestCumulus
+
+  es: 
+    elasticSearchMapping: 6
+
+  iams:
+    ecsRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-ecs'
+    lambdaApiGatewayRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-lambda-api-gateway'
+    lambdaProcessingRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-lambda-processing'
+    stepRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-test-cumulus-steprole'
+    instanceProfile: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:instance-profile/lf-test-cumulus-ecs'
+
+lf:
+  stackName: lf-cumulus
+  stackNameNoDash: lfCumulus
+
+  es: 
+    elasticSearchMapping: 7
+
+  iams:
+    ecsRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-ecs'
+    lambdaApiGatewayRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-lambda-api-gateway'
+    lambdaProcessingRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-lambda-processing'
+    stepRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lf-cumulus-steprole'
+    instanceProfile: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:instance-profile/lf-cumulus-ecs'
+
+lpf:
+  stackName: lpf-cumulus
+  stackNameNoDash: lpfCumulus
+
+  iams:
+    ecsRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-ecs'
+    lambdaApiGatewayRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-lambda-api-gateway'
+    lambdaProcessingRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-lambda-processing'
+    stepRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/lpf-cumulus-steprole'
+    instanceProfile: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:instance-profile/lpf-cumulus-ecs'

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -60,6 +60,16 @@ default:
     stepRoleArn: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/{{prefix}}-integration-steprole'
     instanceProfile: 'arn:aws:iam::{{AWS_ACCOUNT_ID}}:instance-profile/{{prefix}}-integration-ecs'
 
+  sns:
+    inregions3:
+      subscriptions:
+        lambda:
+          endpoint:
+            function: Fn::GetAtt
+            array:
+              - InRegionS3PolicyLambdaFunction
+              - Arn
+
   urs_url: https://uat.urs.earthdata.nasa.gov/ #make sure to include the trailing slash
 
     # if not specified the value of the apigateway backend endpoint is used

--- a/packages/api/lambdas/in-region-s3-policy.js
+++ b/packages/api/lambdas/in-region-s3-policy.js
@@ -109,7 +109,7 @@ async function updateBucketPolicy(bucket, policy) {
 /**
  * Handler
  *
- * @param {Object} event - event passed to lambda. Format:
+ * @param {Object} event - SNS event passed to lambda. Message format:
  * { "create-time":"yyyy-mm-ddThh:mm:ss+00:00",
  *  "synctoken":"0123456789",
  *  "md5":"6a45316e8bc9463c9e926d5d37836d33",
@@ -120,8 +120,12 @@ async function updateBucketPolicy(bucket, policy) {
  * @returns {undefined} - none
  */
 function handler(event, context, callback) {
-  const bucket = event.bucket || defaultBucket;
-  generatePolicy(event.url, defaultRegion, bucket)
+  // Extract the message from the SNS event
+  const message = JSON.parse(event.Records[0].Sns.Message);
+
+  const bucket = message.bucket || defaultBucket;
+
+  generatePolicy(message.url, defaultRegion, bucket)
     .then((policy) => updateBucketPolicy(bucket, policy))
     .then((data) => callback(null, data))
     .catch((err) => callback(err));

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -126,6 +126,24 @@ Resources:
   # SNS config BEGIN
   #################################################
 {{#each sns}}
+  {{#if this.arn}}
+  {{@key}}:
+    Type: "AWS::SNS::Topic"
+    Properties:
+      Subscription:
+        {{#each this.subscriptions}}
+          {{# if this.endpoint.function}}
+          - Endpoint:
+              {{this.endpoint.function}}:
+              {{#each this.endpoint.array}}
+                - {{@this}}
+              {{/each}}
+          {{else}}
+          - Endpoint: {{this.endpoint}}
+          {{/if}}
+            Protocol: {{@key}}
+        {{/each}}
+  {{else}}
   {{@key}}Sns:
     Type: "AWS::SNS::Topic"
     Properties:
@@ -143,6 +161,7 @@ Resources:
         {{/if}}
           Protocol: {{@key}}
       {{/each}}
+  {{/if}}
 
   {{# each this.subscriptions}}
   {{@../key}}SubscriptionPermission:
@@ -160,7 +179,11 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: sns.amazonaws.com
       SourceArn:
+        {{#if ../this.arn}}
+        {{../this.arn}}
+        {{else}}
         Ref: {{@../key}}Sns
+        {{/if}}
   {{/each}}
 
 {{/each}}
@@ -897,9 +920,14 @@ Outputs:
 {{/if}}
 
 {{#each sns}}
+  {{#if this.arn}}
+  {{@key}}:
+    Value: {{this.arn}}
+  {{else}}
   {{@key}}SnsArn:
     Value:
       Ref: {{@key}}Sns
+  {{/if}}
 {{/each}}
 
   EncryptedCmrPassword:

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -127,22 +127,23 @@ Resources:
   #################################################
 {{#each sns}}
   {{#if this.arn}}
-  {{@key}}:
-    Type: "AWS::SNS::Topic"
+  {{#each this.subscriptions}}
+  # Subscriptions only
+  {{@../key}}{{@key}}Subscription: 
+    Type: "AWS::SNS::Subscription"
     Properties:
-      Subscription:
-        {{#each this.subscriptions}}
-          {{# if this.endpoint.function}}
-          - Endpoint:
-              {{this.endpoint.function}}:
-              {{#each this.endpoint.array}}
-                - {{@this}}
-              {{/each}}
-          {{else}}
-          - Endpoint: {{this.endpoint}}
-          {{/if}}
-            Protocol: {{@key}}
+      {{# if this.endpoint.function}}
+      Endpoint:
+        {{this.endpoint.function}}:
+        {{#each this.endpoint.array}}
+          - {{@this}}
         {{/each}}
+      {{else}}
+      Endpoint: {{this.endpoint}}
+      {{/if}}
+      Protocol: {{@key}}
+      TopicArn: {{../this.arn}}
+  {{/each}}
   {{else}}
   {{@key}}Sns:
     Type: "AWS::SNS::Topic"


### PR DESCRIPTION
**Summary:** Setup in-region S3 lambda to subscribe to SNS topics

Addresses [CUMULUS-471] (https://bugs.earthdata.nasa.gov/browse/CUMULUS-471)

## Changes

* Updated the in-region S3 lambda to accept data from SNS, updated integration tests
* Created a test topic and subscribed to that in example config.yml
* Added deployment support to subscribe to existing SNS topics by ARN

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Adhoc testing
- [x] Update CHANGELOG
- [x] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [x] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
