### PR TITLE
Allow removing ElasticSearch from a deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Deployment support to subscribe to an SNS topic that already exists
 - **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to update bucket policy for in-region access. 
+- You can now deploy cumulus without ElasticSearch. Just add `es: null` to your config.yml file. This is only useful for debugging purposes. Cumulus still requires ElasticSearch to properly operates.
 
 ## [v1.5.1] - 2018-04-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Deployment support to subscribe to an SNS topic that already exists
 - **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to update bucket policy for in-region access. 
-- You can now deploy cumulus without ElasticSearch. Just add `es: null` to your config.yml file. This is only useful for debugging purposes. Cumulus still requires ElasticSearch to properly operates.
+- You can now deploy cumulus without ElasticSearch. Just add `es: null` to your `app/config.yml` file. This is only useful for debugging purposes. Cumulus still requires ElasticSearch to properly operate.
 
 ## [v1.5.1] - 2018-04-23
 ### Fixed

--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -7,12 +7,7 @@ sqs2sf:
 sns2elasticsearch:
   handler: index.indexer
   timeout: 100
-  envs:
-    ES_HOST:
-      function: "Fn::GetAtt"
-      array:
-        - '{{es.name}}Domain'
-        - DomainEndpoint
+  useElasticSearch: '{{es.name}}'
   memory: 256
   source: 'node_modules/@cumulus/api/dist/'
 
@@ -20,12 +15,7 @@ log2elasticsearch:
   handler: index.logHandler
   timeout: 100
   memory: 256
-  envs:
-    ES_HOST:
-      function: "Fn::GetAtt"
-      array:
-        - '{{es.name}}Domain'
-        - DomainEndpoint
+  useElasticSearch: '{{es.name}}'
   source: 'node_modules/@cumulus/api/dist/'
 
 sf2snsStart:
@@ -45,12 +35,7 @@ dbIndexer:
   timeout: 300
   memory: 512
   source: 'node_modules/@cumulus/api/dist/'
-  envs:
-    ES_HOST:
-      function: "Fn::GetAtt"
-      array:
-        - '{{es.name}}Domain'
-        - DomainEndpoint
+  useElasticSearch: '{{es.name}}'
 
 kinesisConsumer:
   handler: index.kinesisConsumer
@@ -87,12 +72,7 @@ jobs:
   handler: index.jobs
   timeout: 300
   memory: 512
-  envs:
-    ES_HOST:
-      function: "Fn::GetAtt"
-      array:
-        - '{{es.name}}Domain'
-        - DomainEndpoint
+  useElasticSearch: '{{es.name}}'
   source: 'node_modules/@cumulus/api/dist/'
 
 # used as custom resource for cloudformation manipulation

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -30,10 +30,12 @@ Resources:
           Fn::GetAtt:
             - CumulusCustomResource
             - CmrPassword 
+      {{#if es.name}}
         ElasticSearchDomain:
           Fn::GetAtt:
             - {{../es.name}}Domain
             - DomainEndpoint
+      {{/if}}
         log2elasticsearchLambdaFunction:
           Fn::GetAtt:
             - log2elasticsearchLambdaFunction
@@ -410,20 +412,6 @@ Resources:
   # APIGateway config BEGIN
   #################################################
 {{# if apiMethods}}
-# {{# each apiDependencies}}
-#   ApiGatewayDeployment{{../apiStage}}{{name}}:
-# {{# if methods }}
-#     DependsOn:
-#   {{#each methods}}
-#     - {{name}}
-#   {{/each}}
-# {{/if}}
-#     Type: AWS::ApiGateway::Deployment
-#     Properties:
-#       RestApiId:
-#         Ref: {{name}}RestApi
-#       StageName: {{../apiStage}}
-# {{/each}}
 
 {{#each apiMethods}}
   {{name}}:
@@ -525,6 +513,12 @@ Resources:
       Environment:
         Variables:
           stackName: {{../stackName}}
+        {{#if this.useElasticSearch }}
+          ES_HOST:
+            Fn::GetAtt:
+              - {{../es.name}}Domain
+              - DomainEndpoint
+        {{/if}}
     {{#each this.envs}}
       {{# if this.function}}
         {{#if this.array}}

--- a/packages/deployment/app/cumulus_api.template.yml
+++ b/packages/deployment/app/cumulus_api.template.yml
@@ -9,6 +9,7 @@ Parameters:
     Type: String
     Description: 'ElasticSearch Url'
     NoEcho: true
+    Default: 'noValue'
   SecurityGroupId:
     Type: String
     Description: 'Security Group ID'


### PR DESCRIPTION
**Summary:** Summary of changes

This is a very useful feature for quick debugging of a broken deployment. ElasticSearch creation and deletion takes a longtime. This feature considerably improves the deployment debugging.

## Changes

- You can now deploy cumulus without ElasticSearch. Just add `es: null` to your config.yml file. This is only useful for debugging purposes. Cumulus still requires ElasticSearch to properly operates.

## Test Plan
Things that should succeed before merging.

- [x] Adhoc testing
- [x] Update CHANGELOG
