### PR TITLE
Add rules seeding to integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Deployment support to subscribe to an SNS topic that already exists
-- **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to update bucket policy for in-region access. 
+- **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to update bucket policy for in-region access.
+- `@cumulus/integration-tests` includes and exports the `addRules` function, which seeds rules into the DynamoDB table.
 
 ## [v1.5.1] - 2018-04-23
 ### Fixed

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -182,8 +182,7 @@ function setProcessEnvironment(stackName, bucketName) {
 const concurrencyLimit = process.env.CONCURRENCY || 3;
 const limit = pLimit(concurrencyLimit);
 
-async function readSeedFiles(config, dataDirectory) {
-  const { stackName, bucketName } = config;
+async function readSeedFiles(stackName, bucketName, dataDirectory) {
   setProcessEnvironment(stackName, bucketName);
   const filenames = await fs.readdir(dataDirectory);
   const seedItems = [];
@@ -202,8 +201,8 @@ async function readSeedFiles(config, dataDirectory) {
  * @param {string} dataDirectory - the directory of collection json files
  * @returns {Promise.<integer>} number of collections added
  */
-async function addCollections(config, dataDirectory) {
-  const collections = await readSeedFiles(config, dataDirectory);
+async function addCollections(stackName, bucketName, dataDirectory) {
+  const collections = await readSeedFiles(stackName, bucketName, dataDirectory);
   const promises = collections.map((collection) => limit(() => {  
     const c = new Collection();
     console.log(`adding collection ${collection.name}___${collection.version}`);
@@ -221,8 +220,8 @@ async function addCollections(config, dataDirectory) {
  * @param {string} dataDirectory - the directory of provider json files
  * @returns {Promise.<integer>} number of providers added
  */
-async function addProviders(config, dataDirectory) {
-  const providers = await readSeedFiles(config, dataDirectory);
+async function addProviders(stackName, bucketName, dataDirectory) {
+  const providers = await readSeedFiles(stackName, bucketName, dataDirectory);
 
   const promises = providers.map((provider) => limit(() => {
     const p = new Provider();
@@ -241,7 +240,8 @@ async function addProviders(config, dataDirectory) {
  * @returns {Promise.<integer>} number of rules added
  */
 async function addRules(config, dataDirectory) {
-  const rules = await readSeedFiles(config, dataDirectory);
+  const { stackName, bucketName } = config;
+  const rules = await readSeedFiles(stackName, bucketName, dataDirectory);
 
   const promises = rules.map((rule) => limit(() => {
     const ruleTemplate = Handlebars.compile(JSON.stringify(rule));

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -176,7 +176,7 @@ function setProcessEnvironment(stackName, bucketName) {
   process.env.kinesisConsumer = `${stackName}-kinesisConsumer`;
   process.env.CollectionsTable = `${stackName}-CollectionsTable`;
   process.env.ProvidersTable = `${stackName}-ProvidersTable`;
-  process.env.RulesTable = `${stackName}-RulesTable`;  
+  process.env.RulesTable = `${stackName}-RulesTable`;
 }
 
 const concurrencyLimit = process.env.CONCURRENCY || 3;
@@ -203,7 +203,7 @@ async function setupSeedData(stackName, bucketName, dataDirectory) {
  */
 async function addCollections(stackName, bucketName, dataDirectory) {
   const collections = await setupSeedData(stackName, bucketName, dataDirectory);
-  const promises = collections.map((collection) => limit(() => {  
+  const promises = collections.map((collection) => limit(() => {
     const c = new Collection();
     console.log(`adding collection ${collection.name}___${collection.version}`);
     return c.delete({ name: collection.name, version: collection.version })

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -321,5 +321,6 @@ module.exports = {
   getLambdaOutput: new sfnStep.LambdaStep().getStepOutput,
   addCollections,
   addProviders,
-  addRules
+  addRules,
+  timeout
 };

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -182,6 +182,14 @@ function setProcessEnvironment(stackName, bucketName) {
 const concurrencyLimit = process.env.CONCURRENCY || 3;
 const limit = pLimit(concurrencyLimit);
 
+/**
+ * Set environment variables and read in seed files from dataDirectory
+ *
+ * @param {string} stackName - Cloud formation stack name
+ * @param {string} bucketName - S3 internal bucket name
+ * @param {string} dataDirectory - the directory of collection json files
+ * @return {Array} List of objects to seed in the database
+ */
 async function setupSeedData(stackName, bucketName, dataDirectory) {
   setProcessEnvironment(stackName, bucketName);
   const filenames = await fs.readdir(dataDirectory);

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -182,7 +182,7 @@ function setProcessEnvironment(stackName, bucketName) {
 const concurrencyLimit = process.env.CONCURRENCY || 3;
 const limit = pLimit(concurrencyLimit);
 
-async function readSeedFiles(stackName, bucketName, dataDirectory) {
+async function setupSeedData(stackName, bucketName, dataDirectory) {
   setProcessEnvironment(stackName, bucketName);
   const filenames = await fs.readdir(dataDirectory);
   const seedItems = [];
@@ -202,7 +202,7 @@ async function readSeedFiles(stackName, bucketName, dataDirectory) {
  * @returns {Promise.<integer>} number of collections added
  */
 async function addCollections(stackName, bucketName, dataDirectory) {
-  const collections = await readSeedFiles(stackName, bucketName, dataDirectory);
+  const collections = await setupSeedData(stackName, bucketName, dataDirectory);
   const promises = collections.map((collection) => limit(() => {  
     const c = new Collection();
     console.log(`adding collection ${collection.name}___${collection.version}`);
@@ -221,7 +221,7 @@ async function addCollections(stackName, bucketName, dataDirectory) {
  * @returns {Promise.<integer>} number of providers added
  */
 async function addProviders(stackName, bucketName, dataDirectory) {
-  const providers = await readSeedFiles(stackName, bucketName, dataDirectory);
+  const providers = await setupSeedData(stackName, bucketName, dataDirectory);
 
   const promises = providers.map((provider) => limit(() => {
     const p = new Provider();
@@ -234,14 +234,13 @@ async function addProviders(stackName, bucketName, dataDirectory) {
 /**
  * add rules to database
  *
- * @param {string} stackName - Cloud formation stack name
- * @param {string} bucketName - S3 internal bucket name
+ * @param {string} config - Test config used to set environmenet variables and template rules data
  * @param {string} dataDirectory - the directory of rules json files
  * @returns {Promise.<integer>} number of rules added
  */
 async function addRules(config, dataDirectory) {
   const { stackName, bucketName } = config;
-  const rules = await readSeedFiles(stackName, bucketName, dataDirectory);
+  const rules = await setupSeedData(stackName, bucketName, dataDirectory);
 
   const promises = rules.map((rule) => limit(() => {
     const ruleTemplate = Handlebars.compile(JSON.stringify(rule));

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -326,5 +326,6 @@ module.exports = {
   addCollections,
   addProviders,
   addRules,
-  timeout
+  timeout,
+  getWorkflowArn
 };

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -29,6 +29,7 @@
     "aws-sdk": "^2.224.1",
     "commander": "^2.9.0",
     "fs-extra": "^5.0.0",
+    "handlebars": "^4.0.11",
     "lodash.clonedeep": "^4.5.0",
     "p-limit": "^1.2.0",
     "uuid": "^3.2.1"


### PR DESCRIPTION
**Summary:** Adds `addRules` function to support integration tests for a workflow that is kicked off from a kinesis record. This is in use by [podaac's integration tests](https://git.earthdata.nasa.gov/projects/NGAP/repos/podaac-cumulus-deploy/browse?at=refs/heads/dev) (in active development).

## Changes

* Added `addRules` function
* Refactor `add*` functions to use function `setupSeedData` which includes shared functionality for 

## Test Plan
- [x] integration tests from source (https://circleci.com/gh/cumulus-nasa/cumulus/2189)
- [x] integration tests passing in [podaac's integration tests](https://git.earthdata.nasa.gov/projects/NGAP/repos/podaac-cumulus-deploy/browse?at=refs/heads/dev)
- [x] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased