### PR TITLE
CUMULUS-534: Track deleted granules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to update bucket policy for in-region access. 
 - You can now deploy cumulus without ElasticSearch. Just add `es: null` to your `app/config.yml` file. This is only useful for debugging purposes. Cumulus still requires ElasticSearch to properly operate.
 - `@cumulus/integration-tests` includes and exports the `addRules` function, which seeds rules into the DynamoDB table.
+- **CUMULUS-534** Track deleted granules
+  - added `deletedgranule` type to `cumulus` index.
 
 ## [v1.5.1] - 2018-04-23
 ### Fixed

--- a/packages/api/models/mappings.json
+++ b/packages/api/models/mappings.json
@@ -166,6 +166,57 @@
       }
     }
   },
+  "deletedgranule": {
+    "dynamic_templates": [
+      {
+        "all_date_fileds": {
+          "match": "*At",
+          "match_mapping_type": "long",
+          "mapping": {
+            "type": "date"
+          }
+        }
+      }
+    ],
+    "_parent": {
+      "type": "collection"
+    },
+    "properties": {
+      "execution": {
+        "type": "keyword"
+      },
+      "granuleId": {
+        "type": "keyword"
+      },
+      "pdrName": {
+        "type": "keyword"
+      },
+      "collectionId": {
+        "type": "keyword"
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "provider": {
+        "type": "keyword"
+      },
+      "cmrLink": {
+        "type": "keyword"
+      },
+      "published": {
+        "type": "boolean"
+      },
+      "duration": {
+        "type": "float"
+      },
+      "timestamp": {
+        "type": "date"
+      },
+      "deletedAt": {
+        "type": "date"
+      }
+    }
+  },
   "provider": {
     "dynamic_templates": [
       {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "ava": "^0.25.0",
+    "delay": "^2.0.0",
     "nyc": "^11.6.0",
     "sinon": "^4.5.0",
     "webpack": "~4.5.0",

--- a/packages/api/tests/test-es-indexer.js
+++ b/packages/api/tests/test-es-indexer.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 const fs = require('fs');
 const clone = require('lodash.clonedeep');
 const path = require('path');
+const delay = require('delay');
 const aws = require('@cumulus/common/aws');
 const { StepFunction } = require('@cumulus/ingest/aws');
 const { randomString } = require('@cumulus/common/test-utils');
@@ -179,6 +180,109 @@ test.serial('indexing a granule record in meta section', async (t) => {
   t.is(record._parent, collectionId);
   t.is(record._id, granule.granuleId);
   t.is(record._source.published, false);
+});
+
+test.serial('indexing a deletedgranule record', async (t) => {
+  const granuletype = 'granule';
+  const granule = granuleSuccess.payload.granules[0];
+  granule.granuleId = randomString();
+  const collection = granuleSuccess.meta.collection;
+  const collectionId = indexer.constructCollectionId(collection.name, collection.version);
+
+  // create granule record
+  let r = await indexer.granule(esClient, granuleSuccess, esIndex, granuletype);
+  t.is(r[0].result, 'created');
+  // delete granule record
+  r = await indexer.deleteRecord(esClient, granule.granuleId, granuletype, collectionId, esIndex);
+  t.is(r.result, 'deleted');
+
+  // the deletedgranule record is added
+  const deletedGranParams = {
+    index: esIndex,
+    type: 'deletedgranule',
+    id: granule.granuleId,
+    parent: collectionId
+  };
+
+  let record = await esClient.get(deletedGranParams);
+  t.true(record.found);
+  t.deepEqual(record._source.files, granule.files);
+  t.is(record._parent, collectionId);
+  t.is(record._id, granule.granuleId);
+  t.truthy(record._source.deletedAt);
+
+  // the deletedgranule record is removed if the granule is ingested again
+  r = await indexer.granule(esClient, granuleSuccess, esIndex, granuletype);
+  t.is(r[0].result, 'created');
+  record = await esClient.get(Object.assign(deletedGranParams, { ignore: [404] }));
+  t.false(record.found);
+});
+
+test.serial('indexing multiple deletedgranule records and retrieving them', async (t) => {
+  const granuleIds = [];
+  const newPayload = clone(granuleSuccess);
+  const granuletype = 'granule';
+  const granule = newPayload.payload.granules[0];
+  granule.granuleId = randomString();
+  granuleIds.push(granule.granuleId);
+  for (let i = 0; i < 10; i += 1) {
+    const newgran = clone(granule);
+    newgran.granuleId = randomString();
+    newPayload.payload.granules.push(newgran);
+    granuleIds.push(newgran.granuleId);
+  }
+
+  const collection = newPayload.meta.collection;
+  const collectionId = indexer.constructCollectionId(collection.name, collection.version);
+
+  let response = await indexer.granule(esClient, newPayload, esIndex, granuletype);
+
+  t.is(response.length, 11);
+  const promises = response.map((r) => {
+    t.is(r.result, 'created');
+    // delete granules
+    return indexer.deleteRecord(esClient, r._id, granuletype, collectionId, esIndex);
+  });
+
+  response = await Promise.all(promises);
+  t.is(response.length, 11);
+  response.forEach((r) => t.is(r.result, 'deleted'));
+
+  // retrieve deletedgranule records which are deleted within certain range
+  // and are from a given collection
+  const deletedGranParams = {
+    index: esIndex,
+    type: 'deletedgranule',
+    body: {
+      query: {
+        bool: {
+          must: [
+            {
+              range: {
+                deletedAt: {
+                  gte: 'now-1d',
+                  lt: 'now'
+                }
+              }
+            },
+            {
+              parent_id: {
+                type: 'deletedgranule',
+                id: collectionId
+              }
+            }]
+        }
+      }
+    }
+  };
+
+  await delay(1000);
+  response = await esClient.search(deletedGranParams);
+  t.is(response.hits.total, 11);
+  response.hits.hits.forEach((r) => {
+    t.is(r._parent, collectionId);
+    t.true(granuleIds.includes(r._source.granuleId));
+  });
 });
 
 test.serial('indexing a rule record', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-534: Track deleted granules](https://bugs.earthdata.nasa.gov/browse/CUMULUS-534)

## Changes

* add `deletedgranule` type to `cumulus` index

## TODO
test in AWS

## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [ ] Adhoc testing
- [x ] Update CHANGELOG
- [x ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
