### PR TITLE
Fallback ip in cmrjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@cumulus/integration-tests` includes and exports the `addRules` function, which seeds rules into the DynamoDB table.
 - Added capability to support EFS in cloud formation template. Also added optional capability to ssh to your instance and privileged lambda functions.
 - Added support to force discovery of PDRs that have already been processed and filtering of selected data types
+- `@cumulus/cmrjs` uses an environment variable `USER_IP_ADDRESS` or fallback IP address of `10.0.0.0` when a public IP address is not available. This supports lambda functions deployed into a VPC's private subnet, where no public IP address is available.
 
 ## [v1.5.1] - 2018-04-23
 ### Fixed

--- a/packages/cmrjs/tests/utils-spec.js
+++ b/packages/cmrjs/tests/utils-spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const sinon = require('sinon');
+const test = require('ava');
+const publicIp = require('public-ip');
+
+const { getIp } = require('../utils');
+
+let stub;
+
+test.afterEach(t => {
+  stub.restore();
+});
+
+test('getIp returns public IP when available', async (t) => {
+  const fakeIp = '123.456.78.9';
+  stub = sinon.stub(publicIp, 'v4').resolves(fakeIp);
+  t.is(await getIp(), fakeIp);
+});
+
+test('getIp returns fallback IP when no public IP is available', async (t) => {
+  const fallbackIp = '10.0.0.0';
+  stub = sinon.stub(publicIp, 'v4').rejects(new Error('Query timed out'));
+  t.is(await getIp(), fallbackIp);
+});
+
+test('getIp throws an error when the error is unexpected', async (t) => {
+  const errorMessage = 'Server is experiencing an identity crisis';
+  stub = sinon.stub(publicIp, 'v4').rejects(new Error(errorMessage));
+  await getIp().catch((e) => {
+    t.is(e.message, errorMessage);
+  });
+});

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -158,7 +158,7 @@ async function updateToken(cmrProvider, clientId, username, password) {
   const ip = await publicIp.v4()
     .catch((err) => {
       if (err.message === 'Query timed out') {
-        process.env.USER_IP_ADDRESS || null;
+        process.env.USER_IP_ADDRESS || '10.0.0.0';
       } else {
         throw err;
       }

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -158,7 +158,7 @@ async function updateToken(cmrProvider, clientId, username, password) {
   const ip = await publicIp.v4()
     .catch((err) => {
       if (err.message === 'Query timed out') {
-        process.env.USER_IP_ADDRESS || '10.0.0.0';
+        return process.env.USER_IP_ADDRESS || '10.0.0.0';
       } else {
         throw err;
       }

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -155,6 +155,15 @@ async function updateToken(cmrProvider, clientId, username, password) {
   // Update the saved ECHO token
   // for info on how to add collections to CMR: https://cmr.earthdata.nasa.gov/ingest/site/ingest_api_docs.html#validate-collection
   let response;
+  const ip = await publicIp.v4()
+    .catch((err) => {
+      if (err.message === 'Query timed out') {
+        process.env.USER_IP_ADDRESS || null;
+      } else {
+        throw err;
+      }
+    });
+
   try {
     response = await got.post(getUrl('token'), {
       json: true,
@@ -163,7 +172,7 @@ async function updateToken(cmrProvider, clientId, username, password) {
           username: username,
           password: password,
           client_id: clientId,
-          user_ip_address: await publicIp.v4(),
+          user_ip_address: ip,
           provider: cmrProvider
         }
       }

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -148,7 +148,7 @@ async function validate(type, xml, identifier, provider) {
  * For Lambdas which are launched into a private subnet, no public IP is available
  * and the function falls back to an environment variable, if defined, and  a
  * static string if not defined. The value returned should be a valid IP address or
- * else the request for a valid CMR token will fail.
+ * else the request for a CMR token will fail.
  *
  * @return {String} IP address
  */

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -143,6 +143,27 @@ async function validate(type, xml, identifier, provider) {
 }
 
 /**
+ * Returns IP address.
+ *
+ * For Lambdas which are launched into a private subnet, no public IP is available
+ * and the function falls back to an environment variable, if defined, and  a
+ * static string if not defined. The value returned should be a valid IP address or
+ * else the request for a valid CMR token will fail.
+ *
+ * @return {String} IP address
+ */
+async function getIp() {
+  return await publicIp.v4()
+    .catch((err) => {
+      if (err.message === 'Query timed out') {
+        return process.env.USER_IP_ADDRESS || '10.0.0.0';
+      } else {
+        throw err;
+      }
+    });
+};
+
+/**
  * Returns a valid a CMR token
  *
  * @param {string} cmrProvider - the CMR provider id
@@ -155,14 +176,6 @@ async function updateToken(cmrProvider, clientId, username, password) {
   // Update the saved ECHO token
   // for info on how to add collections to CMR: https://cmr.earthdata.nasa.gov/ingest/site/ingest_api_docs.html#validate-collection
   let response;
-  const ip = await publicIp.v4()
-    .catch((err) => {
-      if (err.message === 'Query timed out') {
-        return process.env.USER_IP_ADDRESS || '10.0.0.0';
-      } else {
-        throw err;
-      }
-    });
 
   try {
     response = await got.post(getUrl('token'), {
@@ -172,7 +185,7 @@ async function updateToken(cmrProvider, clientId, username, password) {
           username: username,
           password: password,
           client_id: clientId,
-          user_ip_address: ip,
+          user_ip_address: await getIp(),
           provider: cmrProvider
         }
       }
@@ -222,5 +235,6 @@ module.exports = {
   ValidationError,
   updateToken,
   getUrl,
-  xmlParseOptions
+  xmlParseOptions,
+  getIp
 }


### PR DESCRIPTION
**Summary:**

`@cumulus/cmrjs` uses an environment variable `USER_IP_ADDRESS` or fallback IP address of `10.0.0.0` when a public IP address is not available. This supports lambda functions deployed into a VPC's private subnet, where no public IP address is available.

## Test Plan

- [x] Unit tests passing
- [x] Adhoc testing (via PODAAC deployment)
- [x] Update CHANGELOG