### PR TITLE
CUMULUS-547 Add earthdataLoginUser to distribution redirect url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - updated cmrjs.deleteConcept to return success if the record is not found in CMR.
 
 ### Added
+- **CUMULUS-547** - The distribution API now includes an
+  "earthdataLoginUsername" query parameter when it returns a signed S3 URL
 - **CUMULUS-527 - "parse-pdr queues up all granules and ignores regex"**
   - Add an optional config property to the ParsePdr task called
     "granuleIdFilter". This property is a regular expression that is applied
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-534** Track deleted granules
   - added `deletedgranule` type to `cumulus` index.
   - **Important Note:** Force custom bootstrap to re-run by adding this to app/config.yml
-  `es: 
+  `es:
       elasticSearchMapping: 7`
 - Added capability to support EFS in cloud formation template. Also added optional capability to ssh to your instance and privileged lambda functions.
 - Added support to force discovery of PDRs that have already been processed and filtering of selected data types

--- a/packages/api/endpoints/distribution.js
+++ b/packages/api/endpoints/distribution.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const get = require('lodash.get');
-const AWS = require('aws-sdk');
 const got = require('got');
-const FormData = require('form-data');
 const querystring = require('querystring');
 const log = require('@cumulus/common/log');
+const { aws } = require('@cumulus/common');
+const { URL } = require('url');
 
 /**
  * An AWS API Gateway function that either requests authentication,
@@ -36,8 +36,6 @@ function handler(event, context, cb) {
   const EARTHDATA_GET_CODE_URL = `${EARTHDATA_BASE_URL}/oauth/authorize`;
   const EARTHDATA_CHECK_CODE_URL = `${EARTHDATA_BASE_URL}/oauth/token`;
 
-  const s3 = new AWS.S3();
-
   let granuleKey = null;
   let query = {};
 
@@ -53,15 +51,15 @@ function handler(event, context, cb) {
   // code means that this is a redirect back from
   // earthData login
   if (query.code) {
-    const form = new FormData();
-    form.append('grant_type', 'authorization_code');
-    form.append('code', query.code);
-    form.append('redirect_uri', DEPLOYMENT_ENDPOINT);
-
     // we send the code to another endpoint to verify
     return got.post(EARTHDATA_CHECK_CODE_URL, {
-      body: form,
       json: true,
+      form: true,
+      body: {
+        grant_type: 'authorization_code',
+        code: query.code,
+        redirect_url: DEPLOYMENT_ENDPOINT
+      },
       auth: `${EARTHDATA_CLIENT_ID}:${EARTHDATA_CLIENT_PASSWORD}`
     }).then((r) => {
       const tokenInfo = r.body;
@@ -78,10 +76,16 @@ function handler(event, context, cb) {
       const user = tokenInfo.endpoint.replace('/api/users/', '');
 
       // otherwise we get the temp url and provide it to the user
-      const url = s3.getSignedUrl('getObject', {
+      const signedUrl = aws.s3().getSignedUrl('getObject', {
         Bucket: process.env.protected,
         Key: granuleKey
       });
+
+      // Add earthdataLoginUsername to signed url
+      const parsedSignedUrl = new URL(signedUrl);
+      const signedUrlParams = parsedSignedUrl.searchParams;
+      signedUrlParams.set('earthdataLoginUsername', user);
+      parsedSignedUrl.search = signedUrlParams.toString();
 
       // now that we have the URL we have to save user's info
       log.info({
@@ -96,8 +100,8 @@ function handler(event, context, cb) {
         statusCode: '302',
         body: 'redirecting',
         headers: {
-          Location: url,
-          'Strict-Transport-Security': 'max-age=31536000' 
+          Location: parsedSignedUrl.toString(),
+          'Strict-Transport-Security': 'max-age=31536000'
         }
       });
     }).catch((e) => cb(e));

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -34,7 +34,6 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/api": "^1.5.0",
     "@cumulus/cmrjs": "^1.5.0",
     "@cumulus/common": "^1.5.0",
     "@cumulus/ingest": "^1.5.0",
@@ -46,7 +45,6 @@
     "commander": "^2.15.0",
     "dynamodb-data-types": "^3.0.0",
     "elasticsearch": "^14.2.2",
-    "form-data": "^2.1.2",
     "got": "^7.1.0",
     "http-aws-es": "^1.1.3",
     "lambda-proxy-utils": "^1.4.0",

--- a/packages/api/tests/test-endpoints-distribution.js
+++ b/packages/api/tests/test-endpoints-distribution.js
@@ -2,8 +2,10 @@
 
 const test = require('ava');
 const { URL } = require('url');
-const { FakeEarthdataLoginServer, randomString } = require('@cumulus/common').testUtils;
-
+const {
+  testUtils: { randomString },
+  FakeEarthdataLoginServer
+} = require('@cumulus/common');
 const distributionEndpoint = require('../endpoints/distribution');
 
 test.beforeEach((t) => {

--- a/packages/api/tests/test-endpoints-distribution.js
+++ b/packages/api/tests/test-endpoints-distribution.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const test = require('ava');
+const { URL } = require('url');
+const { FakeEarthdataLoginServer, randomString } = require('@cumulus/common').testUtils;
+
+const distributionEndpoint = require('../endpoints/distribution');
+
+test.beforeEach((t) => {
+  process.env.protected = 'protected-bucket';
+
+  t.context.fakeEarthdataLoginServer = new FakeEarthdataLoginServer();
+});
+
+test.afterEach.always((t) => {
+  t.context.fakeEarthdataLoginServer.close();
+});
+
+test.serial.cb("The S3 redirect includes the user's URS username", (t) => {
+  // Start the EarthdataLogin server and run the test
+  t.context.fakeEarthdataLoginServer.listen(() => {
+    process.env.EARTHDATA_BASE_URL = t.context.fakeEarthdataLoginServer.endpoint;
+
+    const myUsername = randomString();
+    const code = t.context.fakeEarthdataLoginServer.createAuthorizationCodeForUser(myUsername);
+
+    const event = {
+      pathParameters: {
+        granuleId: 'my-granule-id'
+      },
+      queryStringParameters: {
+        code,
+        state: 'granule-key'
+      }
+    };
+
+    // Call the distribution endpoint handler
+    distributionEndpoint(event, {}, (err, handlerResponse) => {
+      if (err) throw t.end(err);
+
+      t.is(handlerResponse.statusCode, '302');
+
+      const redirectLocation = new URL(handlerResponse.headers.Location);
+      t.is(redirectLocation.searchParams.get('earthdataLoginUsername'), myUsername);
+
+      t.end();
+    });
+  });
+});

--- a/packages/api/tests/test-endpoints-distribution.js
+++ b/packages/api/tests/test-endpoints-distribution.js
@@ -7,7 +7,7 @@ const { FakeEarthdataLoginServer, randomString } = require('@cumulus/common').te
 const distributionEndpoint = require('../endpoints/distribution');
 
 test.beforeEach((t) => {
-  process.env.protected = 'protected-bucket';
+  process.env.protected = randomString();
 
   t.context.fakeEarthdataLoginServer = new FakeEarthdataLoginServer();
 });
@@ -16,7 +16,7 @@ test.afterEach.always((t) => {
   t.context.fakeEarthdataLoginServer.close();
 });
 
-test.serial.cb("The S3 redirect includes the user's URS username", (t) => {
+test.serial.cb("The S3 redirect includes the user's Earthdata Login username", (t) => {
   // Start the EarthdataLogin server and run the test
   t.context.fakeEarthdataLoginServer.listen(() => {
     process.env.EARTHDATA_BASE_URL = t.context.fakeEarthdataLoginServer.endpoint;
@@ -26,11 +26,11 @@ test.serial.cb("The S3 redirect includes the user's URS username", (t) => {
 
     const event = {
       pathParameters: {
-        granuleId: 'my-granule-id'
+        granuleId: randomString()
       },
       queryStringParameters: {
         code,
-        state: 'granule-key'
+        state: randomString()
       }
     };
 

--- a/packages/common/fake-earthdata-login-server.js
+++ b/packages/common/fake-earthdata-login-server.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const formidable = require('formidable');
+const http = require('http');
+const { URL } = require('url');
+const { randomString } = require('./test-utils');
+
+// This class runs a simulated Earthdata Login server
+class FakeEarthdataLoginServer extends http.Server {
+  constructor() {
+    super();
+
+    this.usernamesByCode = {};
+
+    this.on('request', (request, response) => {
+      const requestUrl = new URL(request.url, this.endpoint);
+
+      if (request.method === 'POST' && requestUrl.pathname === '/oauth/token') {
+        this.handleAccessTokenRequest(request, response);
+      }
+      else {
+        response.statusCode = 404;
+        response.end();
+      }
+    });
+  }
+
+  /**
+   * Create an authorization code for the given user.
+   *
+   * This is the code that's returned after the user successfully authenticates
+   * against the Earthdata Login service and is redirected back to Cumulus.
+   *
+   * @param {string} username - username to create the code for
+   * @returns {string} the authorization code
+   */
+  createAuthorizationCodeForUser(username) {
+    const code = randomString();
+    this.usernamesByCode[code] = username;
+    return code;
+  }
+
+  /**
+   * Start the fake Onearth Login server on a random port
+   *
+   * @param {function} cb - The callback that's called when the server is listening
+   * @returns {undefined} no return value
+   */
+  listen(cb) {
+    super.listen(0, '0.0.0.0', cb);
+  }
+
+  /**
+   * Get the URL where the fake Earthdata Login service is listening
+   *
+   * @returns {string} - a URL
+   * @readonly
+   * @memberof FakeEarthdataLoginServer
+   */
+  get endpoint() {
+    const { address, port } = this.address();
+    return `http://${address}:${port}`;
+  }
+
+  // @private
+  handleAccessTokenRequest(request, response) {
+    const form = new formidable.IncomingForm();
+    form.parse(request, (err, fields) => {
+      if (!fields.code) {
+        response.statusCode = 400;
+        return response.end(JSON.stringify({ error: '"code" not set' }));
+      }
+
+      const username = this.usernamesByCode[fields.code];
+      if (!username) {
+        response.statusCode = 404;
+        return response.end(JSON.stringify({ error: `No user found for code ${fields.code}` }));
+      }
+
+      response.setHeader('Content-Type', 'application/json');
+      return response.end(JSON.stringify({
+        access_token: 'abc123',
+        token_type: 'Bearer',
+        expires_in: 123,
+        refresh_token: 'asdf1234',
+        endpoint: `/api/users/${username}`
+      }));
+    });
+  }
+}
+module.exports = FakeEarthdataLoginServer;

--- a/packages/common/index.js
+++ b/packages/common/index.js
@@ -5,3 +5,4 @@ exports.aws = require('./aws');
 exports.task = require('./task');
 exports.cliUtils = require('./cli-utils');
 exports.CollectionConfigStore = require('./collection-config-store');
+exports.testUtils = require('./test-utils');

--- a/packages/common/index.js
+++ b/packages/common/index.js
@@ -6,3 +6,4 @@ exports.task = require('./task');
 exports.cliUtils = require('./cli-utils');
 exports.CollectionConfigStore = require('./collection-config-store');
 exports.testUtils = require('./test-utils');
+exports.FakeEarthdataLoginServer = require('./fake-earthdata-login-server');

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -47,6 +47,7 @@
     "cwait": "^1.0.0",
     "expect.js": "^0.3.1",
     "follow-redirects": "^1.2.4",
+    "formidable": "^1.2.1",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
     "js-yaml": "^3.11.0",

--- a/packages/common/test-utils.js
+++ b/packages/common/test-utils.js
@@ -205,7 +205,7 @@ function jlog(object) {
 }
 exports.jlog = jlog;
 
-// This class runs a simulted Earthdata Login server
+// This class runs a simulated Earthdata Login server
 class FakeEarthdataLoginServer extends http.Server {
   constructor() {
     super();

--- a/packages/common/test-utils.js
+++ b/packages/common/test-utils.js
@@ -1,10 +1,14 @@
 /* eslint-disable no-console */
+
 'use strict';
 
 const Ajv = require('ajv');
 const crypto = require('crypto');
 const path = require('path');
+const formidable = require('formidable');
 const fs = require('fs-extra');
+const http = require('http');
+const { URL } = require('url');
 
 exports.inTestMode = () => process.env.NODE_ENV === 'test';
 
@@ -200,3 +204,88 @@ function jlog(object) {
   console.log(JSON.stringify(object, null, 2));
 }
 exports.jlog = jlog;
+
+// This class runs a simulted Earthdata Login server
+class FakeEarthdataLoginServer extends http.Server {
+  constructor() {
+    super();
+
+    this.usernamesByCode = {};
+
+    this.on('request', (request, response) => {
+      const requestUrl = new URL(request.url, this.endpoint);
+
+      if (request.method === 'POST' && requestUrl.pathname === '/oauth/token') {
+        this.handleAccessTokenRequest(request, response);
+      }
+      else {
+        response.statusCode = 404;
+        response.end();
+      }
+    });
+  }
+
+  /**
+   * Create an authorization code for the given user.
+   *
+   * This is the code that's returned after the user successfully authenticates
+   * against the Earthdata Login service and is redirected back to Cumulus.
+   *
+   * @param {string} username - username to create the code for
+   * @returns {string} the authorization code
+   */
+  createAuthorizationCodeForUser(username) {
+    const code = exports.randomString();
+    this.usernamesByCode[code] = username;
+    return code;
+  }
+
+  /**
+   * Start the fake Onearth Login server on a random port
+   *
+   * @param {function} cb - The callback that's called when the server is listening
+   * @returns {undefined} no return value
+   */
+  listen(cb) {
+    super.listen(0, '0.0.0.0', cb);
+  }
+
+  /**
+   * Get the URL where the fake Earthdata Login service is listening
+   *
+   * @returns {string} - a URL
+   * @readonly
+   * @memberof FakeEarthdataLoginServer
+   */
+  get endpoint() {
+    const { address, port } = this.address();
+    return `http://${address}:${port}`;
+  }
+
+  // @private
+  handleAccessTokenRequest(request, response) {
+    const form = new formidable.IncomingForm();
+    form.parse(request, (err, fields) => {
+      if (!fields.code) {
+        response.statusCode = 400;
+        return response.end(JSON.stringify({ error: '"code" not set' }));
+      }
+
+      const username = this.usernamesByCode[fields.code];
+      if (!username) {
+        response.statusCode = 404;
+        return response.end(JSON.stringify({ error: `No user found for code ${fields.code}` }));
+      }
+
+      response.setHeader('Content-Type', 'application/json');
+      return response.end(JSON.stringify({
+        access_token: 'abc123',
+        token_type: 'Bearer',
+        expires_in: 123,
+        refresh_token: 'asdf1234',
+        endpoint: `/api/users/${username}`
+      }));
+    });
+  }
+}
+exports.FakeEarthdataLoginServer = FakeEarthdataLoginServer;

--- a/packages/common/test-utils.js
+++ b/packages/common/test-utils.js
@@ -5,10 +5,7 @@
 const Ajv = require('ajv');
 const crypto = require('crypto');
 const path = require('path');
-const formidable = require('formidable');
 const fs = require('fs-extra');
-const http = require('http');
-const { URL } = require('url');
 
 exports.inTestMode = () => process.env.NODE_ENV === 'test';
 
@@ -204,88 +201,3 @@ function jlog(object) {
   console.log(JSON.stringify(object, null, 2));
 }
 exports.jlog = jlog;
-
-// This class runs a simulated Earthdata Login server
-class FakeEarthdataLoginServer extends http.Server {
-  constructor() {
-    super();
-
-    this.usernamesByCode = {};
-
-    this.on('request', (request, response) => {
-      const requestUrl = new URL(request.url, this.endpoint);
-
-      if (request.method === 'POST' && requestUrl.pathname === '/oauth/token') {
-        this.handleAccessTokenRequest(request, response);
-      }
-      else {
-        response.statusCode = 404;
-        response.end();
-      }
-    });
-  }
-
-  /**
-   * Create an authorization code for the given user.
-   *
-   * This is the code that's returned after the user successfully authenticates
-   * against the Earthdata Login service and is redirected back to Cumulus.
-   *
-   * @param {string} username - username to create the code for
-   * @returns {string} the authorization code
-   */
-  createAuthorizationCodeForUser(username) {
-    const code = exports.randomString();
-    this.usernamesByCode[code] = username;
-    return code;
-  }
-
-  /**
-   * Start the fake Onearth Login server on a random port
-   *
-   * @param {function} cb - The callback that's called when the server is listening
-   * @returns {undefined} no return value
-   */
-  listen(cb) {
-    super.listen(0, '0.0.0.0', cb);
-  }
-
-  /**
-   * Get the URL where the fake Earthdata Login service is listening
-   *
-   * @returns {string} - a URL
-   * @readonly
-   * @memberof FakeEarthdataLoginServer
-   */
-  get endpoint() {
-    const { address, port } = this.address();
-    return `http://${address}:${port}`;
-  }
-
-  // @private
-  handleAccessTokenRequest(request, response) {
-    const form = new formidable.IncomingForm();
-    form.parse(request, (err, fields) => {
-      if (!fields.code) {
-        response.statusCode = 400;
-        return response.end(JSON.stringify({ error: '"code" not set' }));
-      }
-
-      const username = this.usernamesByCode[fields.code];
-      if (!username) {
-        response.statusCode = 404;
-        return response.end(JSON.stringify({ error: `No user found for code ${fields.code}` }));
-      }
-
-      response.setHeader('Content-Type', 'application/json');
-      return response.end(JSON.stringify({
-        access_token: 'abc123',
-        token_type: 'Bearer',
-        expires_in: 123,
-        refresh_token: 'asdf1234',
-        endpoint: `/api/users/${username}`
-      }));
-    });
-  }
-}
-exports.FakeEarthdataLoginServer = FakeEarthdataLoginServer;


### PR DESCRIPTION
**Summary:** Add earthdataLoginUser to distribution redirect url

Addresses [CUMULUS-547: Update the API's distribution endpoint to include the URS username](https://bugs.earthdata.nasa.gov/browse/CUMULUS-547)

## Changes

* The distribution API now includes an "earthdataLoginUsername" query parameter when it returns a signed S3 URL
* Added a FakeEarthdataLoginServer to the common test utils library.  Currently contains minimal functionality required to support testing CUMULUS-547, but should be easy to add to as needed.

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [x] Update CHANGELOG