### PR TITLE
Release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v1.5.2] - 2018-05-15
+
 ### Fixed
-- **CUMULUS-514 "Unable to Delete the Granules"**
-  - updated cmrjs.deleteConcept to return success if the record is not found in CMR.
+- **CUMULUS-514 - "Unable to Delete the Granules"**
+  - updated cmrjs.deleteConcept to return success if the record is not found
+    in CMR.
 
 ### Added
 - **CUMULUS-527 - "parse-pdr queues up all granules and ignores regex"**
@@ -18,21 +22,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     the output. Defaults to '.', which will match all granules in the PDR.
 - File checksums in PDRs now support MD5
 - Deployment support to subscribe to an SNS topic that already exists
-- **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to update bucket policy for in-region access.
-- **CUMULUS-533** Added fields to granule indexer to support EMS ingest and archive record creation
-- You can now deploy cumulus without ElasticSearch. Just add `es: null` to your `app/config.yml` file. This is only useful for debugging purposes. Cumulus still requires ElasticSearch to properly operate.
-- `@cumulus/integration-tests` includes and exports the `addRules` function, which seeds rules into the DynamoDB table.
+- **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to
+  update bucket policy for in-region access.
+- **CUMULUS-533** Added fields to granule indexer to support EMS ingest and
+  archive record creation
+- You can now deploy cumulus without ElasticSearch. Just add `es: null` to
+  your `app/config.yml` file. This is only useful for debugging purposes.
+  Cumulus still requires ElasticSearch to properly operate.
+- `@cumulus/integration-tests` includes and exports the `addRules` function,
+  which seeds rules into the DynamoDB table.
 - **CUMULUS-534** Track deleted granules
   - added `deletedgranule` type to `cumulus` index.
-  - **Important Note:** Force custom bootstrap to re-run by adding this to app/config.yml
-  `es: 
-      elasticSearchMapping: 7`
-- Added capability to support EFS in cloud formation template. Also added optional capability to ssh to your instance and privileged lambda functions.
-- Added support to force discovery of PDRs that have already been processed and filtering of selected data types
-- `@cumulus/cmrjs` uses an environment variable `USER_IP_ADDRESS` or fallback IP address of `10.0.0.0` when a public IP address is not available. This supports lambda functions deployed into a VPC's private subnet, where no public IP address is available.
+  - **Important Note:** Force custom bootstrap to re-run by adding this to
+    app/config.yml `es: elasticSearchMapping: 7`
+- Added capability to support EFS in cloud formation template. Also added
+  optional capability to ssh to your instance and privileged lambda functions.
+- Added support to force discovery of PDRs that have already been processed
+  and filtering of selected data types
+- `@cumulus/cmrjs` uses an environment variable `USER_IP_ADDRESS` or fallback
+  IP address of `10.0.0.0` when a public IP address is not available. This
+  supports lambda functions deployed into a VPC's private subnet, where no
+  public IP address is available.
 
 ### Changed
-- CUMULUS-550 Custom bootstrap automatically adds new types to index on deployment
+- **CUMULUS-550** Custom bootstrap automatically adds new types to index on
+  deployment
 
 ## [v1.5.1] - 2018-04-23
 ### Fixed
@@ -232,7 +246,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v1.0.0] - 2018-02-23
 
-[Unreleased]: https://github.com/cumulus-nasa/cumulus/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/cumulus-nasa/cumulus/compare/v1.5.2...HEAD
+[v1.5.2]: https://github.com/cumulus-nasa/cumulus/compare/v1.5.1...v1.5.2
 [v1.5.1]: https://github.com/cumulus-nasa/cumulus/compare/v1.5.0...v1.5.1
 [v1.5.0]: https://github.com/cumulus-nasa/cumulus/compare/v1.4.1...v1.5.0
 [v1.4.1]: https://github.com/cumulus-nasa/cumulus/compare/v1.4.0...v1.4.1

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.9.0",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "npmClient": "yarn",
   "packages": [
     "packages/*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/api",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Lambda functions for handling all daac's API operations",
   "main": "index.js",
   "engine": {
@@ -34,10 +34,10 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/api": "^1.5.0",
-    "@cumulus/cmrjs": "^1.5.0",
-    "@cumulus/common": "^1.5.0",
-    "@cumulus/ingest": "^1.5.0",
+    "@cumulus/api": "^1.5.2",
+    "@cumulus/cmrjs": "^1.5.2",
+    "@cumulus/common": "^1.5.2",
+    "@cumulus/ingest": "^1.5.2",
     "@cumulus/pvl": "^1.5.0",
     "ajv": "^5.2.2",
     "archiver": "^2.1.1",

--- a/packages/cmrjs/package.json
+++ b/packages/cmrjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cmrjs",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "A node SDK for CMR",
   "engine": {
     "node": ">=8.10.0"
@@ -31,7 +31,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "got": "^7.1.0",
     "lodash.property": "^4.4.2",
     "public-ip": "^2.3.5",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/common",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Common utilities used across tasks",
   "keywords": [
     "GIBS",
@@ -40,7 +40,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/test-data": "^1.5.2",
     "ajv": "^5.2.2",
     "async": "^2.0.0",
     "aws-sdk": "^2.224.1",

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/deployment",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Deployment templates for cumulus",
   "scripts": {
     "test": "ava --no-color",

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/ingest",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Ingest utilities",
   "engine": {
     "node": ">=8.10.0"
@@ -33,9 +33,9 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/pvl": "^1.5.0",
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/test-data": "^1.5.2",
     "aws-sdk": "^2.224.1",
     "checksum": "^0.1.1",
     "cksum": "^1.3.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/integration-tests",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Integration tests",
   "bin": {
     "cumulus-test": "./bin/cli.js"
@@ -23,9 +23,9 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/api": "^1.5.0",
-    "@cumulus/common": "^1.5.0",
-    "@cumulus/deployment": "^1.5.0",
+    "@cumulus/api": "^1.5.2",
+    "@cumulus/common": "^1.5.2",
+    "@cumulus/deployment": "^1.5.2",
     "aws-sdk": "^2.224.1",
     "commander": "^2.9.0",
     "fs-extra": "^5.0.0",

--- a/packages/task-debug/package.json
+++ b/packages/task-debug/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cumulus/task-debug",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "A harness for debugging workflows.",
   "main": "index.js",
   "homepage": "https://github.com/cumulus-nasa/cumulus#readme",
@@ -18,7 +18,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "commander": "^2.11.0"
   },
   "devDependencies": {

--- a/packages/test-data/package.json
+++ b/packages/test-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/test-data",
-  "version": "1.4.0",
+  "version": "1.5.2",
   "description": "Includes the test data for various packages",
   "keywords": [
     "GIBS",

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/discover-granules",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Discover Granules in FTP/HTTP/HTTPS/SFTP/S3 endpoints",
   "main": "index.js",
   "directories": {
@@ -32,10 +32,10 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/ingest": "^1.5.2",
+    "@cumulus/test-data": "^1.5.2",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/discover-pdrs",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Discover PDRs in FTP and HTTP endpoints",
   "main": "index.js",
   "directories": {
@@ -31,10 +31,10 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/ingest": "^1.5.2",
+    "@cumulus/test-data": "^1.5.2",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/parse-pdr",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Download and Parse a given PDR",
   "main": "index.js",
   "directories": {
@@ -29,10 +29,10 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/ingest": "^1.5.2",
+    "@cumulus/test-data": "^1.5.2",
     "lodash.clonedeep": "^4.4.2",
     "lodash.get": "^4.4.2"
   },

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/pdr-status-check",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Checks execution status of granules in a PDR",
   "main": "index.js",
   "directories": {
@@ -36,10 +36,10 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/ingest": "^1.5.2",
+    "@cumulus/test-data": "^1.5.2",
     "lodash.get": "^4.4.2",
     "p-limit": "^1.1.0"
   },

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/post-to-cmr",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Post a given granule to CMR",
   "main": "index.js",
   "directories": {
@@ -37,11 +37,11 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/cmrjs": "^1.5.0",
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/cmrjs": "^1.5.2",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/ingest": "^1.5.2",
+    "@cumulus/test-data": "^1.5.2",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/queue-granules",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Add discovered granules to the queue",
   "main": "index.js",
   "directories": {
@@ -35,9 +35,9 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
+    "@cumulus/ingest": "^1.5.2",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/queue-pdrs",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Add discovered PDRs to a queue",
   "main": "index.js",
   "directories": {
@@ -35,9 +35,9 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
+    "@cumulus/ingest": "^1.5.2",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/tasks/sf-sns-report/package.json
+++ b/tasks/sf-sns-report/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/sf-sns-report",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Broadcasts an incoming Cumulus message to SNS",
   "main": "index.js",
   "directories": {
@@ -35,9 +35,9 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
+    "@cumulus/ingest": "^1.5.2",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/sync-granule",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Download a given granule",
   "main": "index.js",
   "directories": {
@@ -38,10 +38,10 @@
     ]
   },
   "dependencies": {
-    "@cumulus/common": "^1.5.0",
+    "@cumulus/common": "^1.5.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
-    "@cumulus/ingest": "^1.5.0",
-    "@cumulus/test-data": "^1.4.0",
+    "@cumulus/ingest": "^1.5.2",
+    "@cumulus/test-data": "^1.5.2",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
**Summary:** Release 1.5.2

## Changes

### Fixed
- **CUMULUS-514 - "Unable to Delete the Granules"**
  - updated cmrjs.deleteConcept to return success if the record is not found
    in CMR.

### Added
- **CUMULUS-527 - "parse-pdr queues up all granules and ignores regex"**
  - Add an optional config property to the ParsePdr task called
    "granuleIdFilter". This property is a regular expression that is applied
    against the filename of the first file of each granule contained in the
    PDR. If the regular expression matches, then the granule is included in
    the output. Defaults to '.', which will match all granules in the PDR.
- File checksums in PDRs now support MD5
- Deployment support to subscribe to an SNS topic that already exists
- **CUMULUS-470, CUMULUS-471** In-region S3 Policy lambda added to API to
  update bucket policy for in-region access.
- **CUMULUS-533** Added fields to granule indexer to support EMS ingest and
  archive record creation
- You can now deploy cumulus without ElasticSearch. Just add `es: null` to
  your `app/config.yml` file. This is only useful for debugging purposes.
  Cumulus still requires ElasticSearch to properly operate.
- `@cumulus/integration-tests` includes and exports the `addRules` function,
  which seeds rules into the DynamoDB table.
- **CUMULUS-534** Track deleted granules
  - added `deletedgranule` type to `cumulus` index.
  - **Important Note:** Force custom bootstrap to re-run by adding this to
    app/config.yml `es: elasticSearchMapping: 7`
- Added capability to support EFS in cloud formation template. Also added
  optional capability to ssh to your instance and privileged lambda functions.
- Added support to force discovery of PDRs that have already been processed
  and filtering of selected data types
- `@cumulus/cmrjs` uses an environment variable `USER_IP_ADDRESS` or fallback
  IP address of `10.0.0.0` when a public IP address is not available. This
  supports lambda functions deployed into a VPC's private subnet, where no
  public IP address is available.

### Changed
- **CUMULUS-550** Custom bootstrap automatically adds new types to index on
  deployment
