### PR TITLE
Rename username property that's logged for EMS distribution

### DIFF
--- a/packages/api/endpoints/distribution.js
+++ b/packages/api/endpoints/distribution.js
@@ -84,7 +84,7 @@ function handler(event, context, cb) {
       // Add earthdataLoginUsername to signed url
       const parsedSignedUrl = new URL(signedUrl);
       const signedUrlParams = parsedSignedUrl.searchParams;
-      signedUrlParams.set('earthdataLoginUsername', user);
+      signedUrlParams.set('x-EarthdataLoginUsername', user);
       parsedSignedUrl.search = signedUrlParams.toString();
 
       // now that we have the URL we have to save user's info

--- a/packages/api/tests/test-endpoints-distribution.js
+++ b/packages/api/tests/test-endpoints-distribution.js
@@ -43,7 +43,7 @@ test.serial.cb("The S3 redirect includes the user's Earthdata Login username", (
       t.is(handlerResponse.statusCode, '302');
 
       const redirectLocation = new URL(handlerResponse.headers.Location);
-      t.is(redirectLocation.searchParams.get('earthdataLoginUsername'), myUsername);
+      t.is(redirectLocation.searchParams.get('x-EarthdataLoginUsername'), myUsername);
 
       t.end();
     });


### PR DESCRIPTION
**Summary:** Rename `earthdataLoginUsername` parameter name to `x-EarthdataLoginUsername`

According to the AWS docs, additional query parameters that are added to a signed S3 request should start with `x-`.  Updated the signed requests so that the Earthdata Login username property starts with `x-`.

AWS Docs

> Custom Access Log Information
> 
> You can include custom information to be stored in the access log record for a request by adding a custom query-string parameter to the URL for the request. Amazon S3 will ignore query-string parameters that begin with "x-", but will include those parameters in the access log record for the request, as part of the Request-URI field of the log record. For example, a GET request for "s3.amazonaws.com/mybucket/photos/2014/08/puppy.jpg?x-user=johndoe" will work the same as the same request for "s3.amazonaws.com/mybucket/photos/2014/08/puppy.jpg", except that the "x-user=johndoe" string will be included in the Request-URI field for the associated log record. This functionality is available in the REST interface only. 