### PR TITLE
Fix webpack build aws test

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -21,20 +21,20 @@
     ]
   },
   "dependencies": {
-    "@cumulus/api": "^1.5.1",
-    "@cumulus/common": "^1.5.1",
-    "@cumulus/deployment": "^1.5.1",
-    "@cumulus/discover-granules": "^1.5.1",
-    "@cumulus/discover-pdrs": "^1.5.1",
-    "@cumulus/hello-world": "^1.5.1",
-    "@cumulus/integration-tests": "^1.5.1",
-    "@cumulus/parse-pdr": "^1.5.1",
-    "@cumulus/pdr-status-check": "^1.5.1",
-    "@cumulus/post-to-cmr": "^1.5.1",
-    "@cumulus/queue-granules": "^1.5.1",
-    "@cumulus/queue-pdrs": "^1.5.1",
-    "@cumulus/sf-sns-report": "^1.5.1",
-    "@cumulus/sync-granule": "^1.5.1",
+    "@cumulus/api": "^1.5.2",
+    "@cumulus/common": "^1.5.2",
+    "@cumulus/deployment": "^1.5.2",
+    "@cumulus/discover-granules": "^1.5.2",
+    "@cumulus/discover-pdrs": "^1.5.2",
+    "@cumulus/hello-world": "^1.5.2",
+    "@cumulus/integration-tests": "^1.5.2",
+    "@cumulus/parse-pdr": "^1.5.2",
+    "@cumulus/pdr-status-check": "^1.5.2",
+    "@cumulus/post-to-cmr": "^1.5.2",
+    "@cumulus/queue-granules": "^1.5.2",
+    "@cumulus/queue-pdrs": "^1.5.2",
+    "@cumulus/sf-sns-report": "^1.5.2",
+    "@cumulus/sync-granule": "^1.5.2",
     "aws-sdk": "^2.227.1"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "jasmine": "^3.1.0",
     "jasmine-console-reporter": "^2.0.1",
     "js-yaml": "^3.11.0",
-    "kes": "^2.1.2",
+    "kes": "^2.2.1",
     "lodash": "^4.17.5",
     "node-forge": "^0.7.5"
   }

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/discover-granules/webpack.config.js
+++ b/tasks/discover-granules/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/hello-world/webpack.config.js
+++ b/tasks/hello-world/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/parse-pdr/webpack.config.js
+++ b/tasks/parse-pdr/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/pdr-status-check/webpack.config.js
+++ b/tasks/pdr-status-check/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node',

--- a/tasks/post-to-cmr/webpack.config.js
+++ b/tasks/post-to-cmr/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/queue-granules/webpack.config.js
+++ b/tasks/queue-granules/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/queue-pdrs/webpack.config.js
+++ b/tasks/queue-pdrs/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/sf-sns-report/webpack.config.js
+++ b/tasks/sf-sns-report/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'

--- a/tasks/sync-granule/webpack.config.js
+++ b/tasks/sync-granule/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   externals: [
     'aws-sdk',
-    'electron'
+    'electron',
+    {'formidable': 'url'}
   ],
   devtool,
   target: 'node'


### PR DESCRIPTION
This PR ignores the formidable dependency on the common package when webpacking tasks.

formidable package causes this error when webpacked: 
```
*/const n=r(41).createConnection,i=r(15).EventEmitter,a=r(5).inherits,s=r(6),o=r(4),u=r(306),c=r(303),l=r(298),f=r(48),d=r(296).nfc,h=r(47)("jsftp:general"),p=r(47)("jsftp:command"),m=r(47)("jsftp:response"),y="localhost",_=21,g=function(){},v={marks:[125,150],ignore:226},w=/([-\d]+,[-\d]+,[-\d]+,[-\d]+),([-\d]+),([-\d]+)/,E=/\r\n|\n/;function b(e){this.host=e.host||y,this.port=e.port||_,this.user=e.user||"anonymous",this.pass=e.pass||"@anonymous",this.createSocket=e.createSocket,this.useList=e.useList||!1,this.commandQueue=[],i.call(this),this.on("data",m),this._createSocket(this.port,this.host)}a(b,i),b.prototype.raw=function(){(function(e,...t){let r=g,n=e+" ";"function"==typeof t[t.length-1]&&(r=t.pop()),n+=t.join(" "),this.execute(n.trim(),r)}).apply(this,arguments)},b.prototype.reemit=function(e){return t=>{this.emit(e,t),h(`event:${e}`,t||{})}},b.prototype._createSocket=function(e,t,r=g){this.socket&&this.socket.destro

TypeError: n is not a function
    at Object.<anonymous> 
```