### PR TITLE
Catch bad json in Kinesis Consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- **CUMULUS-546 - Kinesis Consumer should catch and log invalid JSON**
+  - Kinesis Consumer lambda catches and logs errors so that consumer doesn't get stuck in a loop re-processing bad json records.
+
 ## [v1.5.4] - 2018-05-21
 
 ### Added

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -95,15 +95,14 @@ See [Cumulus README](https://github.com/cumulus-nasa/cumulus/blob/master/README.
 
 ## Running Tests
 
-Running tests for kinesis-consumer depends on localstack. Once you have installed localstack, you can start it for dynamoDB only:
+Running tests for kinesis-consumer depends on localstack. Once you have installed localstack, start it:
 
 ```
-LAMBDA_EXECUTOR=docker localstack start
+localstack start
 ```
 
 Then you can run tests locally via:
 
 ```bash
-export DOCKERHOST=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
-LOCALSTACK_HOST=localhost DOCKERHOST=${DOCKERHOST} IS_LOCAL=true npm run test
+LOCALSTACK_HOST=localhost IS_LOCAL=true npm run test
 ```

--- a/packages/api/lambdas/kinesis-consumer.js
+++ b/packages/api/lambdas/kinesis-consumer.js
@@ -86,7 +86,15 @@ function validateMessage(event) {
 function processRecord(record) {
   const dataBlob = record.kinesis.data;
   const dataString = Buffer.from(dataBlob, 'base64').toString();
-  const eventObject = JSON.parse(dataString);
+  let eventObject;
+  try {
+    JSON.parse(dataString);
+  }
+  catch(err) {
+    log.error('Caught error parsing JSON:');
+    log.error(err);
+    return err;
+  };
 
   return validateMessage(eventObject)
     .then(getKinesisRules)

--- a/packages/api/lambdas/kinesis-consumer.js
+++ b/packages/api/lambdas/kinesis-consumer.js
@@ -88,7 +88,7 @@ function processRecord(record) {
   const dataString = Buffer.from(dataBlob, 'base64').toString();
   let eventObject;
   try {
-    JSON.parse(dataString);
+    eventObject = JSON.parse(dataString);
   }
   catch(err) {
     log.error('Caught error parsing JSON:');

--- a/packages/api/tests/test-kinesis-consumer.js
+++ b/packages/api/tests/test-kinesis-consumer.js
@@ -188,6 +188,15 @@ test('it should throw an error if message collection has wrong data type', async
   t.is(errors[0].errors[0].message, 'should be string');
 });
 
+test('it should throw an error if message is invalid json', async(t) => {
+  const invalidMessage = '{';
+  const kinesisEvent = {
+    Records: [{ kinesis: { data: Buffer.from(invalidMessage).toString('base64') } }]
+  };
+  const errors = await handler(kinesisEvent, {}, testCallback);
+  t.is(errors[0].message, 'Unexpected end of JSON input');
+});
+
 test('it should not throw if message is valid', (t) => {
   const validMessage = JSON.stringify({ collection: 'confection-collection' });
   const kinesisEvent = {


### PR DESCRIPTION
**Summary:** 

Addresses [CUMULUS-546: Kinesis Consumer should catch and log invalid JSON](https://bugs.earthdata.nasa.gov/browse/CUMULUS-546)

## Changes

* Update code and add tests
* Update instructions for running tests

## Test Plan

- [x] Unit tests
- [x] Update CHANGELOG
