### PR TITLE
CUMULUS-530: add pdr to syn-granule config and output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **CUMULUS-530** - PDR tracking through Queue-granules
+  - Add optional `pdr` property to the syn-granule task's input config and output payload.
 
 ## [v1.5.4] - 2018-05-21
 
 ### Added
 - **CUMULUS-535** - EMS Ingest, Archive, Archive Delete reports
   - Add lambda EmsReport to create daily EMS Ingest, Archive, Archive Delete reports
-  - ems.provider property added to `@cumulus/deployment/app/config.yml`. 
+  - ems.provider property added to `@cumulus/deployment/app/config.yml`.
     To change the provider name, please add `ems: provider` property to `app/config.yml`.
 
 ## [v1.5.3] - 2018-05-18

--- a/example/spec/parsePdr/ParsePdrSuccessSpec.js
+++ b/example/spec/parsePdr/ParsePdrSuccessSpec.js
@@ -111,12 +111,13 @@ describe('Parse PDR workflow', () => {
     });
 
     describe('SyncGranule lambda function', () => {
-      it('outputs 1 granule', async () => {
+      it('outputs 1 granule and pdr', async () => {
         const lambdaOutput = await lambdaStep.getStepOutput(
           ingestGranuleWorkflowArn,
           'SyncGranule'
         );
         expect(lambdaOutput.payload.granules.length).toEqual(1);
+        expect(lambdaOutput.payload.pdr).toEqual(lambdaOutput.payload.pdr);
       });
     });
   });

--- a/example/workflows.yml
+++ b/example/workflows.yml
@@ -210,9 +210,6 @@ ParsePdr:
     CheckStatus:
       Type: Task
       Resource: ${PdrStatusCheckLambdaFunction.Arn}
-      CumulusConfig:
-        cumulus_message:
-          input: '{$.payload}'
       Catch:
         - ErrorEquals:
           - States.ALL
@@ -232,7 +229,7 @@ ParsePdr:
     PdrStatusReport:
       CumulusConfig:
         cumulus_message:
-          input: '{$.payload}'
+          input: '{$}'
       ResultPath: null
       Type: Task
       Resource: ${SfSnsReportLambdaFunction.Arn}
@@ -294,6 +291,7 @@ IngestGranule:
         buckets: '{$.meta.buckets}'
         provider: '{$.meta.provider}'
         collection: '{$.meta.collection}'
+        pdr: '{$.meta.pdr}'
         cumulus_message:
           outputs:
             - source: '{$.granules}'
@@ -315,6 +313,7 @@ IngestGranule:
         buckets: '{$.meta.buckets}'
         provider: '{$.meta.provider}'
         collection: '{$.meta.collection}'
+        pdr: '{$.meta.pdr}'
         cumulus_message:
           outputs:
             - source: '{$.granules}'
@@ -348,9 +347,6 @@ IngestGranule:
         input_keys: '{$.meta.collection.process_keys}'
         cumulus_message:
           input: '[$.payload.granules[*].files[*].filename]'
-          outputs:
-            - source: '{$}'
-              destination: '{$.payload}'
       Type: Task
       Resource: ${ModisProcessingLambdaFunction.Arn}
       Catch:
@@ -371,11 +367,6 @@ IngestGranule:
         cmr: '{$.meta.cmr}'
         input_granules: '{$.meta.input_granules}'
         granuleIdExtraction: '{$.meta.collection.granuleIdExtraction}'
-        cumulus_message:
-          input: '{$.payload}'
-          outputs:
-            - source: '{$}'
-              destination: '{$.payload}'
       Type: Task
       Resource: ${PostToCmrLambdaFunction.Arn}
       Catch:

--- a/tasks/sync-granule/index.js
+++ b/tasks/sync-granule/index.js
@@ -21,9 +21,8 @@ async function download(ingest, bucket, provider, granules) {
   const proceed = await lock.proceed(bucket, provider, granules[0].granuleId);
 
   if (!proceed) {
-    const err = new errors.ResourcesLockedError(
-      'Download lock remained in place after multiple tries'
-    );
+    const err =
+      new errors.ResourcesLockedError('Download lock remained in place after multiple tries');
     log.error(err);
     throw err;
   }
@@ -78,6 +77,7 @@ exports.syncGranule = function syncGranule(event) {
 
       const output = { granules };
       if (collection.process) output.process = collection.process;
+      if (config.pdr) output.pdr = config.pdr;
 
       return output;
     }).catch((e) => {

--- a/tasks/sync-granule/schemas/config.json
+++ b/tasks/sync-granule/schemas/config.json
@@ -58,6 +58,13 @@
           }
         }
       }
+    },
+    "pdr": {
+      "required": ["name", "path"],
+      "properties": {
+        "name": { "type": "string" },
+        "path": { "type": "string" }
+      }
     }
   }
 }

--- a/tasks/sync-granule/schemas/output.json
+++ b/tasks/sync-granule/schemas/output.json
@@ -33,6 +33,13 @@
           }
         }
       }
+    },
+    "pdr": {
+      "required": ["name", "path"],
+      "properties": {
+        "name": { "type": "string" },
+        "path": { "type": "string" }
+      }
     }
   }
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-530: PDR tracking through Queue-granules](https://bugs.earthdata.nasa.gov/browse/CUMULUS-530)

## Changes

* add pdr to syn-granule config and output

## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [x] Adhoc testing
- [x ] Update CHANGELOG
- [x ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
