### PR TITLE
Fix a couple of yarn warnings in parse-pdr task

### DIFF
--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -2,6 +2,7 @@
   "name": "@cumulus/parse-pdr",
   "version": "1.5.5",
   "description": "Download and Parse a given PDR",
+  "license": "Apache-2.0",
   "main": "index.js",
   "directories": {
     "test": "tests"
@@ -38,13 +39,12 @@
     "@cumulus/cumulus-message-adapter-js": "^1.0.1",
     "@cumulus/ingest": "^1.5.5",
     "@cumulus/test-data": "^1.5.2",
-    "lodash.clonedeep": "^4.4.2",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {
     "ava": "^0.25.0",
     "fs-extra": "^5.0.0",
-    "lodash.clonedeep": "^4.5.0",
     "nyc": "^11.6.0",
     "proxyquire": "^2.0.0",
     "webpack": "~4.5.0",


### PR DESCRIPTION
Yarn was reporting these warnings in CircleCI:

```
@cumulus/parse-pdr
yarn run v1.5.1
warning package.json: No license field
warning package.json: "dependencies" has dependency "lodash.clonedeep" with range "^4.4.2" that collides with a dependency in "devDependencies" of the same name with version "^4.5.0"
```