### PR TITLE
[CUMULUS-544] Fix hardcoded UAT URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **CUMULUS-544** - Post to CMR task has UAT URL hard-coded
-  - Changed to use getUrl. PostToCmr now requires CMR_ENVIRONMENT env to be specified if SIT or OPS are desired. Default is UAT.
+  - Made configurable: PostToCmr now requires CMR_ENVIRONMENT env to be specified if SIT or OPS are desired. Default is UAT.
 
 ## [v1.6.0] - 2018-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **CUMULUS-544** - Post to CMR task has UAT URL hard-coded
-  - Made configurable: PostToCmr now requires CMR_ENVIRONMENT env to be specified if SIT or OPS are desired. Default is UAT.
+  - Made configurable: PostToCmr now requires CMR_ENVIRONMENT env to be set to 'SIT' or 'OPS' for those CMR environments. Default is UAT.
 
 ## [v1.6.0] - 2018-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CUMULUS-544** - Post to CMR task has UAT URL hard-coded
+  - Changed to use getUrl. PostToCmr now requires CMR_ENVIRONMENT env to be specified if SIT or OPS are desired. Default is UAT.
+
 ## [v1.6.0] - 2018-06-06
 
 ### Please note: [Upgrade Instructions](https://github.com/cumulus-nasa/cumulus/wiki/Upgrading-to-Cumulus-1.6)

--- a/tasks/post-to-cmr/index.js
+++ b/tasks/post-to-cmr/index.js
@@ -5,7 +5,7 @@ const path = require('path');
 const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 const { justLocalRun } = require('@cumulus/common/local-helpers');
 const { DefaultProvider } = require('@cumulus/ingest/crypto');
-const { CMR } = require('@cumulus/cmrjs');
+const { CMR, getUrl } = require('@cumulus/cmrjs');
 const { getS3Object } = require('@cumulus/common/aws');
 const { XmlMetaFileNotFound } = require('@cumulus/common/errors');
 const { xmlParseOptions } = require('@cumulus/cmrjs/utils');
@@ -132,8 +132,7 @@ async function publish(cmrFile, creds, bucket, stack) {
     granuleId: cmrFile.granuleId,
     filename: cmrFile.filename,
     conceptId,
-    link: 'https://cmr.uat.earthdata.nasa.gov/search/granules.json' +
-      `?concept_id=${res.result['concept-id']}`
+    link: `${getUrl('search')}granules.json?concept_id=${res.result['concept-id']}`
   };
 }
 

--- a/tasks/post-to-cmr/tests/cmr_test.js
+++ b/tasks/post-to-cmr/tests/cmr_test.js
@@ -31,7 +31,7 @@ test.afterEach.always(async (t) => {
   deleteBucket(t.context.bucket);
 });
 
-test.serial('should succeed if cmr correctly identifies the xml as invalid', async (t) => {
+test.serial('postToCMR throws error if CMR correctly identifies the xml as invalid', async (t) => {
   sinon.stub(cmrjs.CMR.prototype, 'getToken');
 
   const newPayload = JSON.parse(JSON.stringify(payload));
@@ -44,7 +44,7 @@ test.serial('should succeed if cmr correctly identifies the xml as invalid', asy
       Key: key,
       Body: '<?xml version="1.0" encoding="UTF-8"?><results></results>'
     });
-    const output = await postToCMR(newPayload);
+    await postToCMR(newPayload);
     t.fail();
   } catch(e) {
     t.true(e instanceof cmrjs.ValidationError);
@@ -53,7 +53,7 @@ test.serial('should succeed if cmr correctly identifies the xml as invalid', asy
   }
 });
 
-test.serial('should succeed with correct payload', async (t) => {
+test.serial('postToCMR succeeds with correct payload', async (t) => {
   const newPayload = JSON.parse(JSON.stringify(payload));
   sinon.stub(cmrjs.CMR.prototype, 'ingestGranule').callsFake(() => ({
     result
@@ -78,7 +78,7 @@ test.serial('should succeed with correct payload', async (t) => {
   }
 });
 
-test.serial('postToCMR returns SIT url when CMR_ENVIRONMENT==\'SIT\'', async (t) => {
+test.serial('postToCMR returns SIT url when CMR_ENVIRONMENT=="SIT"', async (t) => {
   process.env.CMR_ENVIRONMENT = 'SIT';
   const newPayload = JSON.parse(JSON.stringify(payload));
   sinon.stub(cmrjs.CMR.prototype, 'ingestGranule').callsFake(() => ({
@@ -105,7 +105,7 @@ test.serial('postToCMR returns SIT url when CMR_ENVIRONMENT==\'SIT\'', async (t)
   }
 });
 
-test.serial('Should skip cmr step if the metadata file uri is missing', async (t) => {
+test.serial('postToCMR skips CMR step if the metadata file uri is missing', async (t) => {
   const newPayload = JSON.parse(JSON.stringify(payload));
   newPayload.input.granules = [{
     granuleId: 'some granule',

--- a/tasks/post-to-cmr/tests/cmr_test.js
+++ b/tasks/post-to-cmr/tests/cmr_test.js
@@ -31,29 +31,29 @@ test.afterEach.always(async (t) => {
   deleteBucket(t.context.bucket);
 });
 
-test.serial('should succeed if cmr correctly identifies the xml as invalid', (t) => {
+test.serial('should succeed if cmr correctly identifies the xml as invalid', async (t) => {
   sinon.stub(cmrjs.CMR.prototype, 'getToken');
 
   const newPayload = JSON.parse(JSON.stringify(payload));
   const granuleId = newPayload.input.granules[0].granuleId;
   const key = `${granuleId}.cmr.xml`;
 
-  return aws.promiseS3Upload({
-    Bucket: t.context.bucket,
-    Key: key,
-    Body: '<?xml version="1.0" encoding="UTF-8"?><results></results>'
-  }).then(() => postToCMR(newPayload)
-    .then(() => {
-      cmrjs.CMR.prototype.getToken.restore();
-      t.fail();
-    })
-    .catch((e) => {
-      cmrjs.CMR.prototype.getToken.restore();
-      t.true(e instanceof cmrjs.ValidationError);
-    }));
+  try {
+    await aws.promiseS3Upload({
+      Bucket: t.context.bucket,
+      Key: key,
+      Body: '<?xml version="1.0" encoding="UTF-8"?><results></results>'
+    });
+    const output = await postToCMR(newPayload);
+    t.fail();
+  } catch(e) {
+    t.true(e instanceof cmrjs.ValidationError);
+  } finally {
+    cmrjs.CMR.prototype.getToken.restore();
+  }
 });
 
-test.serial('should succeed with correct payload', (t) => {
+test.serial('should succeed with correct payload', async (t) => {
   const newPayload = JSON.parse(JSON.stringify(payload));
   sinon.stub(cmrjs.CMR.prototype, 'ingestGranule').callsFake(() => ({
     result
@@ -61,26 +61,24 @@ test.serial('should succeed with correct payload', (t) => {
   const granuleId = newPayload.input.granules[0].granuleId;
   const key = `${granuleId}.cmr.xml`;
 
-  return aws.promiseS3Upload({
-    Bucket: t.context.bucket,
-    Key: key,
-    Body: fs.createReadStream('tests/data/meta.xml')
-  }).then(() => postToCMR(newPayload)
-    .then((output) => {
-      cmrjs.CMR.prototype.ingestGranule.restore();
-      t.is(
-        output.granules[0].cmrLink,
-        `https://cmr.uat.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
-      );
-    })
-    .catch((e) => {
-      console.log(e);
-      cmrjs.CMR.prototype.ingestGranule.restore();
-      t.fail();
-    }));
+  try {
+    await aws.promiseS3Upload({
+      Bucket: t.context.bucket,
+      Key: key,
+      Body: fs.createReadStream('tests/data/meta.xml')
+    });
+    const output = await postToCMR(newPayload);
+    t.is(
+      output.granules[0].cmrLink,
+      `https://cmr.uat.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
+    );
+  }
+  finally {
+    cmrjs.CMR.prototype.ingestGranule.restore();
+  }
 });
 
-test.serial('should succeed with correct payload and return SIT url', (t) => {
+test.serial('postToCMR returns SIT url when CMR_ENVIRONMENT==\'SIT\'', async (t) => {
   process.env.CMR_ENVIRONMENT = 'SIT';
   const newPayload = JSON.parse(JSON.stringify(payload));
   sinon.stub(cmrjs.CMR.prototype, 'ingestGranule').callsFake(() => ({
@@ -88,29 +86,26 @@ test.serial('should succeed with correct payload and return SIT url', (t) => {
   }));
   const granuleId = newPayload.input.granules[0].granuleId;
   const key = `${granuleId}.cmr.xml`;
-
-  return aws.promiseS3Upload({
-    Bucket: t.context.bucket,
-    Key: key,
-    Body: fs.createReadStream('tests/data/meta.xml')
-  }).then(() => postToCMR(newPayload)
-    .then((output) => {
-      cmrjs.CMR.prototype.ingestGranule.restore();
-      delete process.env.CMR_ENVIRONMENT;
-      t.is(
-        output.granules[0].cmrLink,
-        `https://cmr.sit.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
-      );
-    })
-    .catch((e) => {
-      delete process.env.CMR_ENVIRONMENT;
-      console.log(e);
-      cmrjs.CMR.prototype.ingestGranule.restore();
-      t.fail();
-    }));
+  
+  try {
+    await aws.promiseS3Upload({
+      Bucket: t.context.bucket,
+      Key: key,
+      Body: fs.createReadStream('tests/data/meta.xml')
+    });
+    const output = await postToCMR(newPayload);
+    t.is(
+      output.granules[0].cmrLink,
+      `https://cmr.sit.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
+    );
+  }
+  finally {
+    cmrjs.CMR.prototype.ingestGranule.restore();
+    delete process.env.CMR_ENVIRONMENT;
+  }
 });
 
-test.serial('Should skip cmr step if the metadata file uri is missing', (t) => {
+test.serial('Should skip cmr step if the metadata file uri is missing', async (t) => {
   const newPayload = JSON.parse(JSON.stringify(payload));
   newPayload.input.granules = [{
     granuleId: 'some granule',
@@ -119,9 +114,6 @@ test.serial('Should skip cmr step if the metadata file uri is missing', (t) => {
     }]
   }];
 
-  return postToCMR(newPayload)
-    .then((output) => {
-      t.is(output.granules[0].cmr, undefined);
-    })
-    .catch(t.fail);
+  const output = await postToCMR(newPayload);
+  t.is(output.granules[0].cmr, undefined);
 });

--- a/tasks/post-to-cmr/tests/cmr_test.js
+++ b/tasks/post-to-cmr/tests/cmr_test.js
@@ -96,12 +96,14 @@ test.serial('should succeed with correct payload and return SIT url', (t) => {
   }).then(() => postToCMR(newPayload)
     .then((output) => {
       cmrjs.CMR.prototype.ingestGranule.restore();
+      delete process.env.CMR_ENVIRONMENT;
       t.is(
         output.granules[0].cmrLink,
         `https://cmr.sit.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
       );
     })
     .catch((e) => {
+      delete process.env.CMR_ENVIRONMENT;
       console.log(e);
       cmrjs.CMR.prototype.ingestGranule.restore();
       t.fail();

--- a/tasks/post-to-cmr/tests/cmr_test.js
+++ b/tasks/post-to-cmr/tests/cmr_test.js
@@ -80,6 +80,34 @@ test.serial('should succeed with correct payload', (t) => {
     }));
 });
 
+test.serial('should succeed with correct payload and return SIT url', (t) => {
+  process.env.CMR_ENVIRONMENT = 'SIT';
+  const newPayload = JSON.parse(JSON.stringify(payload));
+  sinon.stub(cmrjs.CMR.prototype, 'ingestGranule').callsFake(() => ({
+    result
+  }));
+  const granuleId = newPayload.input.granules[0].granuleId;
+  const key = `${granuleId}.cmr.xml`;
+
+  return aws.promiseS3Upload({
+    Bucket: t.context.bucket,
+    Key: key,
+    Body: fs.createReadStream('tests/data/meta.xml')
+  }).then(() => postToCMR(newPayload)
+    .then((output) => {
+      cmrjs.CMR.prototype.ingestGranule.restore();
+      t.is(
+        output.granules[0].cmrLink,
+        `https://cmr.sit.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
+      );
+    })
+    .catch((e) => {
+      console.log(e);
+      cmrjs.CMR.prototype.ingestGranule.restore();
+      t.fail();
+    }));
+});
+
 test.serial('Should skip cmr step if the metadata file uri is missing', (t) => {
   const newPayload = JSON.parse(JSON.stringify(payload));
   newPayload.input.granules = [{


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-544: Post to CMR task has UAT URL hard-coded](https://bugs.earthdata.nasa.gov/browse/CUMULUS-544)

## Changes

* Use getUrl from cmrjs
* Defaults to UAT url, requires CMR_ENVIRONMENT env to specify `SIT` or `OPS`

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Update CHANGELOG
