### PR TITLE
[CUMULUS-544] Fix hardcoded UAT URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - **CUMULUS-602** - Format all logs sent to Elastic Search.
   - Extract cumulus log message and index it to Elastic Search.
+- **CUMULUS-544** - Post to CMR task has UAT URL hard-coded
+  - Made configurable: PostToCmr now requires CMR_ENVIRONMENT env to be set to 'SIT' or 'OPS' for those CMR environments. Default is UAT.
 
 ### Added
 - **CUMULUS-556** - add a mechanism for creating and running migration scripts on deployment.

--- a/packages/ingest/cmr.js
+++ b/packages/ingest/cmr.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { CMR } = require('@cumulus/cmrjs');
+const { CMR, getUrl } = require('@cumulus/cmrjs');
 const { DefaultProvider } = require('./crypto');
 const log = require('@cumulus/common/log');
 
@@ -45,8 +45,7 @@ async function publish(cmrFile, creds, bucket, stack) {
     granuleId: cmrFile.granuleId,
     filename: cmrFile.filename,
     conceptId,
-    link: 'https://cmr.uat.earthdata.nasa.gov/search/granules.json' +
-    `?concept_id=${res.result['concept-id']}`
+    link: `${getUrl('search')}granules.json?concept_id=${res.result['concept-id']}`
   };
 }
 

--- a/tasks/post-to-cmr/tests/cmr_test.js
+++ b/tasks/post-to-cmr/tests/cmr_test.js
@@ -39,29 +39,29 @@ test.afterEach.always(async (t) => {
   deleteBucket(t.context.bucket);
 });
 
-test.serial('should succeed if cmr correctly identifies the xml as invalid', (t) => {
+test.serial('postToCMR throws error if CMR correctly identifies the xml as invalid', async (t) => {
   sinon.stub(cmrjs.CMR.prototype, 'getToken');
 
   const newPayload = JSON.parse(JSON.stringify(payload));
   const granuleId = newPayload.input.granules[0].granuleId;
   const key = `${granuleId}.cmr.xml`;
 
-  return aws.promiseS3Upload({
-    Bucket: t.context.bucket,
-    Key: key,
-    Body: '<?xml version="1.0" encoding="UTF-8"?><results></results>'
-  }).then(() => postToCMR(newPayload)
-    .then(() => {
-      cmrjs.CMR.prototype.getToken.restore();
-      t.fail();
-    })
-    .catch((e) => {
-      cmrjs.CMR.prototype.getToken.restore();
-      t.true(e instanceof cmrjs.ValidationError);
-    }));
+  try {
+    await aws.promiseS3Upload({
+      Bucket: t.context.bucket,
+      Key: key,
+      Body: '<?xml version="1.0" encoding="UTF-8"?><results></results>'
+    });
+    await postToCMR(newPayload);
+    t.fail();
+  } catch(e) {
+    t.true(e instanceof cmrjs.ValidationError);
+  } finally {
+    cmrjs.CMR.prototype.getToken.restore();
+  }
 });
 
-test.serial('should succeed with correct payload', (t) => {
+test.serial('postToCMR succeeds with correct payload', async (t) => {
   const newPayload = JSON.parse(JSON.stringify(payload));
   sinon.stub(cmrjs.CMR.prototype, 'ingestGranule').callsFake(() => ({
     result
@@ -69,26 +69,51 @@ test.serial('should succeed with correct payload', (t) => {
   const granuleId = newPayload.input.granules[0].granuleId;
   const key = `${granuleId}.cmr.xml`;
 
-  return aws.promiseS3Upload({
-    Bucket: t.context.bucket,
-    Key: key,
-    Body: fs.createReadStream('tests/data/meta.xml')
-  }).then(() => postToCMR(newPayload)
-    .then((output) => {
-      cmrjs.CMR.prototype.ingestGranule.restore();
-      t.is(
-        output.granules[0].cmrLink,
-        `https://cmr.uat.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
-      );
-    })
-    .catch((e) => {
-      console.log(e);
-      cmrjs.CMR.prototype.ingestGranule.restore();
-      t.fail();
-    }));
+  try {
+    await aws.promiseS3Upload({
+      Bucket: t.context.bucket,
+      Key: key,
+      Body: fs.createReadStream('tests/data/meta.xml')
+    });
+    const output = await postToCMR(newPayload);
+    t.is(
+      output.granules[0].cmrLink,
+      `https://cmr.uat.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
+    );
+  }
+  finally {
+    cmrjs.CMR.prototype.ingestGranule.restore();
+  }
 });
 
-test.serial('Should skip cmr step if the metadata file uri is missing', (t) => {
+test.serial('postToCMR returns SIT url when CMR_ENVIRONMENT=="SIT"', async (t) => {
+  process.env.CMR_ENVIRONMENT = 'SIT';
+  const newPayload = JSON.parse(JSON.stringify(payload));
+  sinon.stub(cmrjs.CMR.prototype, 'ingestGranule').callsFake(() => ({
+    result
+  }));
+  const granuleId = newPayload.input.granules[0].granuleId;
+  const key = `${granuleId}.cmr.xml`;
+  
+  try {
+    await aws.promiseS3Upload({
+      Bucket: t.context.bucket,
+      Key: key,
+      Body: fs.createReadStream('tests/data/meta.xml')
+    });
+    const output = await postToCMR(newPayload);
+    t.is(
+      output.granules[0].cmrLink,
+      `https://cmr.sit.earthdata.nasa.gov/search/granules.json?concept_id=${result['concept-id']}`
+    );
+  }
+  finally {
+    cmrjs.CMR.prototype.ingestGranule.restore();
+    delete process.env.CMR_ENVIRONMENT;
+  }
+});
+
+test.serial('postToCMR skips CMR step if the metadata file uri is missing', async (t) => {
   const newPayload = JSON.parse(JSON.stringify(payload));
   newPayload.input.granules = [{
     granuleId: 'some granule',
@@ -97,9 +122,6 @@ test.serial('Should skip cmr step if the metadata file uri is missing', (t) => {
     }]
   }];
 
-  return postToCMR(newPayload)
-    .then((output) => {
-      t.is(output.granules[0].cmr, undefined);
-    })
-    .catch(t.fail);
+  const output = await postToCMR(newPayload);
+  t.is(output.granules[0].cmr, undefined);
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-544: Post to CMR task has UAT URL hard-coded](https://bugs.earthdata.nasa.gov/browse/CUMULUS-544)

## Changes

* Use getUrl from cmrjs
* Defaults to UAT url, requires CMR_ENVIRONMENT env to specify `SIT` or `OPS`

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Update CHANGELOG