### PR TITLE
Cumulus 398

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-508** - `@cumulus/deployment` cloudformation template allows for lambdas and ECS clusters to have multiple AZ availability.
     - `@cumulus/deployment` also ensures docker uses `devicemapper` storage driver.
 
+### Fixed
+- **CUMULUS-398** - Fix not able to filter executions bu workflow
+
 ## [v1.6.0] - 2018-06-06
 
 ### Please note: [Upgrade Instructions](https://github.com/cumulus-nasa/cumulus/wiki/Upgrading-to-Cumulus-1.6)

--- a/packages/api/endpoints/stats.js
+++ b/packages/api/endpoints/stats.js
@@ -64,16 +64,13 @@ function average(event, cb) {
 function handler(event, context) {
   log.debug(event);
   handle(event, context, true, (cb) => {
-    if (event.httpMethod === 'GET' && event.resource === '/stats') {
-      summary(event, cb);
-    }
-    else if (event.httpMethod === 'GET' && event.resource === '/stats/histogram') {
+    if (event.httpMethod === 'GET' && event.resource.includes('/stats/histogram')) {
       histogram(event, cb);
     }
-    else if (event.httpMethod === 'GET' && event.resource === '/stats/aggregate') {
+    else if (event.httpMethod === 'GET' && event.resource.includes('/stats/aggregate')) {
       count(event, cb);
     }
-    else if (event.httpMethod === 'GET' && event.resource === '/stats/average') {
+    else if (event.httpMethod === 'GET' && event.resource.includes('/stats/average')) {
       average(event, cb);
     }
     else {

--- a/packages/api/es/queries.js
+++ b/packages/api/es/queries.js
@@ -182,10 +182,6 @@ module.exports = function(params) {
       'sort_by',
       'order',
       'prefix',
-      'type',
-      'interval',
-      'format',
-      'field',
       'fields'
     ]
   );

--- a/packages/api/es/search.js
+++ b/packages/api/es/search.js
@@ -52,7 +52,7 @@ class BaseSearch {
         },
 
         // Note that this doesn't abort the query.
-        requestTimeout: 50000  // milliseconds
+        requestTimeout: 50000 // milliseconds
       };
     }
 
@@ -311,7 +311,6 @@ class BaseSearch {
       return e;
     }
   }
-
 }
 
 class Search extends BaseSearch {}

--- a/packages/api/es/stats.js
+++ b/packages/api/es/stats.js
@@ -2,8 +2,27 @@
 
 const moment = require('moment');
 const { BaseSearch } = require('./search');
+const omit = require('lodash.omit');
 
 class Stats extends BaseSearch {
+  /**
+   * Remove stats-specific fields, then create search
+   *
+   * @returns {Object} - search params
+   */
+  _buildSearch() {
+    this.params = omit(
+      this.params,
+      [
+        'type',
+        'interval',
+        'format',
+        'field'
+      ]
+    );
+
+    return super._buildSearch();
+  }
 
   async query() {
     if (!this.client) {

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -10,7 +10,7 @@ const { randomString } = require('@cumulus/common/test-utils');
  * @param {Function} endpoint - the lambda function used as ApiGateway backend
  * @param {Object} event - aws lambda event object
  * @param {Function} testCallback - aws lambda callback function
- * @returns {Promise<object>} the promise returned by the lambda function
+ * @returns {Promise<Object>} the promise returned by the lambda function
  */
 function testEndpoint(endpoint, event, testCallback) {
   return new Promise((resolve, reject) => {
@@ -82,14 +82,16 @@ function fakePdrFactory(status = 'completed') {
  * creates fake execution records
  *
  * @param {string} status - pdr status (default to completed)
+ * @param {string} type - workflow type (default to fakeWorkflow)
  * @returns {Object} fake execution object
  */
-function fakeExecutionFactory(status = 'completed') {
+function fakeExecutionFactory(status = 'completed', type = 'fakeWorkflow') {
   return {
     arn: randomString(),
     name: randomString(),
     status,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    type
   };
 }
 

--- a/packages/api/migrations/migration_1.js
+++ b/packages/api/migrations/migration_1.js
@@ -28,7 +28,7 @@ async function copyEsToDynamoDB(Cls, index = 'cumulus', type, concurrency = 1, p
 
 
   // catch possible duplicate granule records
-  const hash = {}
+  const hash = {};
   res.hits.hits.forEach((s) => {
     hash[s._id] = s._source;
   });

--- a/packages/api/tests/test-endpoints-executions.js
+++ b/packages/api/tests/test-endpoints-executions.js
@@ -12,7 +12,7 @@ const { Search } = require('../es/search');
 
 // create all the variables needed across this test
 let esClient;
-let fakeExecutions;
+let fakeExecutions = [];
 const hash = { name: 'arn', type: 'S' };
 const esIndex = randomString();
 process.env.ExecutionsTable = randomString();
@@ -36,8 +36,7 @@ test.before(async () => {
   // create fake granule records
   fakeExecutions = ['completed', 'failed'].map(fakeExecutionFactory);
   await Promise.all(fakeExecutions.map((i) => ex.create(i)
-    .then((record) => indexer.indexExecution(esClient, record, esIndex))
-  ));
+    .then((record) => indexer.indexExecution(esClient, record, esIndex))));
 });
 
 test.after.always(async () => {


### PR DESCRIPTION
**Summary:** Fix executions not filtering by workflow

Addresses [CUMULUS-398](https://bugs.earthdata.nasa.gov/browse/CUMULUS-398)

## Changes

* Put stats-specific param omissions into stats API code, since 'type' in stats overlaps with 'type' in executions.

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
