### PR TITLE
CUMULUS-747: Delete granule API doesn't delete granule files and granule in elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-508** - `@cumulus/deployment` cloudformation template allows for lambdas and ECS clusters to have multiple AZ availability.
     - `@cumulus/deployment` also ensures docker uses `devicemapper` storage driver.
 
+### Fixed
+- **CCUMULUS-747** - Delete granule API doesn't delete granule files in s3 and granule in elasticsearch
+    - update the StreamSpecification DynamoDB tables to have StreamViewType: "NEW_AND_OLD_IMAGES"
+    - delete granule files in s3
+
 ## [v1.6.0] - 2018-06-06
 
 ### Please note: [Upgrade Instructions](https://github.com/cumulus-nasa/cumulus/wiki/Upgrading-to-Cumulus-1.6)

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -89,9 +89,14 @@ async function del(event) {
     throw new Error(errMsg);
   }
 
-  // remove file from s3
-  const key = `${process.env.stackName}/granules_ingested/${granuleId}`;
-  await aws.deleteS3Object(process.env.internal, key);
+  // remove files from s3
+  await Promise.all(record.files.map((file) => {
+    const parsed = aws.parseS3Uri(file.filename);
+    if (aws.fileExists(parsed.Bucket, parsed.Key)) {
+      return aws.deleteS3Object(parsed.Bucket, parsed.Key);
+    }
+    return {};
+  }));
 
   await g.delete({ granuleId });
 

--- a/packages/api/models/base.js
+++ b/packages/api/models/base.js
@@ -47,7 +47,7 @@ class Manager {
       },
       StreamSpecification: {
         StreamEnabled: true,
-        StreamViewType: 'NEW_IMAGE'
+        StreamViewType: 'NEW_AND_OLD_IMAGES'
       }
     };
 

--- a/packages/api/tests/test-db-indexer.js
+++ b/packages/api/tests/test-db-indexer.js
@@ -194,6 +194,10 @@ test.serial('create, update and delete a granule in dynamodb and es', async (t) 
 
   indexedRecord = await granuleIndex.get(fakeGranule.granuleId);
   t.is(indexedRecord.detail, 'Record not found');
+
+  const deletedGranIndex = new Search({}, 'deletedgranule');
+  const deletedGranRecord = await deletedGranIndex.get(fakeGranule.granuleId);
+  t.is(deletedGranRecord.granuleId, fakeGranule.granuleId);
 });
 
 test.serial('create, update and delete an execution in dynamodb and es', async (t) => {

--- a/packages/api/tests/test-es-indexer.js
+++ b/packages/api/tests/test-es-indexer.js
@@ -239,6 +239,7 @@ test.serial('creating multiple deletedgranule records and retrieving them', asyn
   // add the records
   let response = await Promise.all(granules.map((g) => indexer.indexGranule(esClient, g, esIndex)));
   t.is(response.length, 11);
+  await esClient.indices.refresh();
 
   // now delete the records
   response = await Promise.all(granules
@@ -247,6 +248,8 @@ test.serial('creating multiple deletedgranule records and retrieving them', asyn
 
   t.is(response.length, 11);
   response.forEach((r) => t.is(r.result, 'deleted'));
+
+  await esClient.indices.refresh();
 
   // retrieve deletedgranule records which are deleted within certain range
   // and are from a given collection
@@ -261,7 +264,7 @@ test.serial('creating multiple deletedgranule records and retrieving them', asyn
               range: {
                 deletedAt: {
                   gte: 'now-1d',
-                  lt: 'now'
+                  lte: 'now+1s'
                 }
               }
             },
@@ -276,7 +279,6 @@ test.serial('creating multiple deletedgranule records and retrieving them', asyn
     }
   };
 
-  await esClient.indices.refresh();
   response = await esClient.search(deletedGranParams);
   t.is(response.hits.total, 11);
   response.hits.hits.forEach((r) => {

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -408,7 +408,7 @@ Resources:
         WriteCapacityUnits: {{this.write}}
       TableName: {{../stackName}}-{{@key}}
       StreamSpecification:
-        StreamViewType: "NEW_IMAGE"
+        StreamViewType: "NEW_AND_OLD_IMAGES"
 
 {{/each}}
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-747: Delete granule API doesn't delete granule files in s3 and granule in elasticsearch](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* update the StreamSpecification DynamoDB tables to have StreamViewType: "NEW_AND_OLD_IMAGES"
* delete granule files in s3

## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [x ] Adhoc testing
- [x ] Update CHANGELOG
- [x ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
