### PR TITLE
Cumulus-721 Adding SNS checks in integration test

### DIFF
--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -161,6 +161,7 @@ lf:
 
 kk-uat-deployment:
   stackName: kk-test-uat
+  prefix: kk-test-uat
   stackNameNoDash: KkTestUat
 
   iams:

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -109,13 +109,7 @@ default:
     # step functions
     sftracker:
       subscriptions:
-        lambda:
-          endpoint:
-            function: Fn::GetAtt
-            array:
-              - sns2elasticsearchLambdaFunction
-              - Arn
-        lambda:
+        2ndlambda:
           endpoint:
             function: Fn::GetAtt
             array:

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -105,6 +105,22 @@ default:
             array:
               - InRegionS3PolicyLambdaFunction
               - Arn
+    # this topic receives all the updates from
+    # step functions
+    sftracker:
+      subscriptions:
+        lambda:
+          endpoint:
+            function: Fn::GetAtt
+            array:
+              - sns2elasticsearchLambdaFunction
+              - Arn
+        lambda:
+          endpoint:
+            function: Fn::GetAtt
+            array:
+              - SnsS3TestLambdaFunction
+              - Arn
 
   urs_url: https://uat.urs.earthdata.nasa.gov/ #make sure to include the trailing slash
 

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -96,6 +96,7 @@ default:
             array:
               - InRegionS3PolicyLambdaFunction
               - Arn
+          protocol: lambda
     AmazonIpSpaceChanged:
       arn: arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged
       subscriptions:
@@ -105,8 +106,7 @@ default:
             array:
               - InRegionS3PolicyLambdaFunction
               - Arn
-    # this topic receives all the updates from
-    # step functions
+          protocol: lambda
     sftracker:
       subscriptions:
         2ndlambda:
@@ -115,6 +115,7 @@ default:
             array:
               - SnsS3TestLambdaFunction
               - Arn
+          protocol: lambda
 
   urs_url: https://uat.urs.earthdata.nasa.gov/ #make sure to include the trailing slash
 

--- a/example/lambdas.yml
+++ b/example/lambdas.yml
@@ -113,3 +113,7 @@ InRegionS3Policy:
    timeout: 300
    source: 'node_modules/@cumulus/api/dist/'
 
+SnsS3Test:
+  handler: index.handler
+  source: 'lambdas/snsS3Test/'
+

--- a/example/lambdas/snsS3Test/index.js
+++ b/example/lambdas/snsS3Test/index.js
@@ -5,7 +5,7 @@ const { S3 } = require('aws-sdk');
 /**
  * Receives event trigger from SNS and forwards event message to S3 bucket
  *
- * @param {*} event - from SNS
+ * @param {Object} event - from SNS
  * @returns {Promise} confirmation of added message
  */
 async function handler(event) {

--- a/example/lambdas/snsS3Test/index.js
+++ b/example/lambdas/snsS3Test/index.js
@@ -2,6 +2,12 @@
 
 const { S3 } = require('aws-sdk');
 
+/**
+ * Receives event trigger from SNS and forwards event message to S3 bucket
+ *
+ * @param {*} event - from SNS
+ * @returns {Promise} confirmation of added message
+ */
 async function handler(event) {
   const s3 = new S3();
   const messageString = event.Records[0].Sns.Message;

--- a/example/lambdas/snsS3Test/index.js
+++ b/example/lambdas/snsS3Test/index.js
@@ -1,11 +1,14 @@
 'use strict';
 
-const { s3 } = require('@cumulus/common/aws');
+const { S3 } = require('aws-sdk');
 
 async function handler(event) {
-  return s3().putObject({
-    Bucket: event.cumulus_meta.system_bucket,
-    Key: `${event.cumulus_meta.stack}/test-output/${event.cumulus_meta.execution_name}.output`
+  const s3 = new S3();
+  const messageString = event.Records[0].Sns.Message;
+  const message = JSON.parse(messageString);
+  return s3.putObject({
+    Bucket: message.cumulus_meta.system_bucket,
+    Key: `${message.meta.stack}/test-output/${message.cumulus_meta.execution_name}.output`
   }).promise();
 }
 exports.handler = handler;

--- a/example/lambdas/snsS3Test/index.js
+++ b/example/lambdas/snsS3Test/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { s3 } = require('@cumulus/common/aws');
+
+async function handler(event) {
+  return s3().putObject({
+    Bucket: event.cumulus_meta.system_bucket,
+    Key: `${event.cumulus_meta.stack}/test-output/${event.cumulus_meta.execution_name}.output`
+  }).promise();
+}
+exports.handler = handler;

--- a/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1,4 +1,3 @@
-// const AWS = require('aws-sdk');
 const fs = require('fs');
 const urljoin = require('url-join');
 const got = require('got');
@@ -10,7 +9,6 @@ const {
   conceptExists,
   getOnlineResources
 } = require('@cumulus/integration-tests');
-// const sns = new AWS.SNS();
 const { loadConfig, templateFile, getExecutionUrl } = require('../helpers/testUtils');
 const config = loadConfig();
 const lambdaStep = new LambdaStep();

--- a/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1,15 +1,22 @@
+// const AWS = require('aws-sdk');
 const fs = require('fs');
 const urljoin = require('url-join');
 const got = require('got');
 const { Granule, Execution } = require('@cumulus/api/models');
-const { s3, s3ObjectExists } = require('@cumulus/common/aws');
+const {
+  s3,
+  s3ObjectExists,
+  region,
+  sns
+} = require('@cumulus/common/aws');
 const {
   buildAndExecuteWorkflow,
+  getWorkflowTemplate,
   LambdaStep,
   conceptExists,
   getOnlineResources
 } = require('@cumulus/integration-tests');
-
+// const sns = new AWS.SNS();
 const { loadConfig, templateFile, getExecutionUrl } = require('../helpers/testUtils');
 const config = loadConfig();
 const lambdaStep = new LambdaStep();
@@ -36,8 +43,21 @@ describe('The S3 Ingest Granules workflow', () => {
   const granuleModel = new Granule();
   process.env.ExecutionsTable = `${config.stackName}-ExecutionsTable`;
   const executionModel = new Execution();
+  let subscriptionArn;
 
   beforeAll(async () => {
+    const template = await getWorkflowTemplate(config.stackName, config.bucket, taskName);
+    const topicArn = template.topic_arn;
+
+    const params = {
+      TopicArn: topicArn,
+      Protocol: 'lambda',
+      Endpoint: `arn:aws:lambda:${region}:${process.env.AWS_ACCOUNT_ID}:function:${config.stackName}-SnsS3Test`
+    };
+
+    const response = await sns().subscribe(params);
+    subscriptionArn = response.SubscriptionArn;
+
     // delete the granule record from DynamoDB if exists
     await granuleModel.delete({ granuleId: inputPayload.granules[0].granuleId });
 
@@ -45,6 +65,10 @@ describe('The S3 Ingest Granules workflow', () => {
     workflowExecution = await buildAndExecuteWorkflow(
       config.stackName, config.bucket, taskName, collection, provider, inputPayload
     );
+  });
+
+  afterAll(async () => {
+    await sns().unsubscribe({ SubscriptionArn: subscriptionArn });
   });
 
   it('completes execution with success status', () => {
@@ -155,7 +179,7 @@ describe('The S3 Ingest Granules workflow', () => {
 
   describe('the sf-sns-report task has published a sns message and', () => {
     it('the granule record is added to DynamoDB', async () => {
-      const record = await granuleModel.get({ granuleId: inputPayload.granules[0].granuleId }); 
+      const record = await granuleModel.get({ granuleId: inputPayload.granules[0].granuleId });
       expect(record.execution).toEqual(getExecutionUrl(workflowExecution.executionArn));
     });
 

--- a/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
@@ -63,6 +63,7 @@ describe('The S3 Ingest Granules workflow', () => {
 
   afterAll(async () => {
     await s3().deleteObject({ Bucket: config.bucket, Key: `${config.stackName}/test-output/${executionName}.output` }).promise();
+    await s3().deleteObject({ Bucket: config.bucket, Key: `${config.stackName}/test-output/${failedExecutionName}.output` }).promise();
   });
 
   it('completes execution with success status', () => {

--- a/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
@@ -157,7 +157,7 @@ describe('The S3 Ingest Granules workflow', () => {
     });
   });
 
-  describe('the sf-sns-report task has published a sns message', () => {
+  describe('An SNS success message', () => {
     let lambdaOutput;
     let existCheck;
 
@@ -167,16 +167,16 @@ describe('The S3 Ingest Granules workflow', () => {
       existCheck = await s3ObjectExists({ Bucket: config.bucket, Key: `${config.stackName}/test-output/${executionName}.output` });
     });
 
-    it('on workflow completion', async () => {
+    it('is published on workflow completion', async () => {
       expect(existCheck).toEqual(true);
     });
 
-    it('and the granule record is added to DynamoDB', async () => {
+    it('triggers the granule record being added to DynamoDB', async () => {
       const record = await granuleModel.get({ granuleId: inputPayload.granules[0].granuleId });
       expect(record.execution).toEqual(getExecutionUrl(workflowExecution.executionArn));
     });
 
-    it('and the execution record is added to DynamoDB', async () => {
+    it('triggers the execution record being added to DynamoDB', async () => {
       const record = await executionModel.get({ arn: workflowExecution.executionArn });
       expect(record.status).toEqual('completed');
     });

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -155,7 +155,7 @@ Resources:
       {{else}}
       Endpoint: {{this.endpoint}}
       {{/if}}
-      Protocol: lambda
+      Protocol: {{this.protocol}}
       TopicArn: {{../this.arn}}
   {{/each}}
   {{else}}
@@ -174,7 +174,7 @@ Resources:
         {{else}}
         - Endpoint: {{this.endpoint}}
         {{/if}}
-          Protocol: lambda
+          Protocol: {{this.protocol}}
       {{/each}}
   {{/if}}
 

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -155,7 +155,7 @@ Resources:
       {{else}}
       Endpoint: {{this.endpoint}}
       {{/if}}
-      Protocol: {{@key}}
+      Protocol: lambda
       TopicArn: {{../this.arn}}
   {{/each}}
   {{else}}
@@ -174,12 +174,12 @@ Resources:
         {{else}}
         - Endpoint: {{this.endpoint}}
         {{/if}}
-          Protocol: {{@key}}
+          Protocol: lambda
       {{/each}}
   {{/if}}
 
   {{# each this.subscriptions}}
-  {{@../key}}SubscriptionPermission:
+  {{@../key}}{{@key}}SubscriptionPermission:
     Type: AWS::Lambda::Permission
     Properties:
     {{# if this.endpoint.function}}

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -107,6 +107,7 @@ default:
             array:
               - sns2elasticsearchLambdaFunction
               - Arn
+          protocol: lambda
 
   apis:
     - name: download 

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -325,6 +325,7 @@ module.exports = {
   testWorkflow,
   executeWorkflow,
   buildAndExecuteWorkflow,
+  getWorkflowTemplate,
   waitForCompletedExecution,
   ActivityStep: sfnStep.ActivityStep,
   LambdaStep: sfnStep.LambdaStep,


### PR DESCRIPTION
**Summary:** Adding SNS check in integration tests

Addresses [CUMULUS-721: Write an integration test suite demonstrating a message being sent to a SNS topic on completed workflow](https://bugs.earthdata.nasa.gov/browse/CUMULUS-721)

## Changes

* Added new lambda and subscription to catch SNS messages sent during IngestGranule integration test. Updated in example/app/config. Redeployment required
* Added test to check the newly store SNS messages
