### PR TITLE
CUMULUS-746: Move granule API correctly updates record in dynamo DB and cmr xml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - **CUMULUS-491** - Add granule reconciliation API endpoints.
-
-### Added
 - **CUMULUS-508** - `@cumulus/deployment` cloudformation template allows for lambdas and ECS clusters to have multiple AZ availability.
     - `@cumulus/deployment` also ensures docker uses `devicemapper` storage driver.
 
@@ -16,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-747** - Delete granule API doesn't delete granule files in s3 and granule in elasticsearch
     - update the StreamSpecification DynamoDB tables to have StreamViewType: "NEW_AND_OLD_IMAGES"
     - delete granule files in s3
-- **CUMULUS-398** - Fix not able to filter executions bu workflow
+- **CUMULUS-398** - Fix not able to filter executions by workflow
+- **CUMULUS-746** - Move granule API correctly updates record in dynamo DB and cmr xml file
 
 ## [v1.6.0] - 2018-06-06
 

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -201,3 +201,19 @@ mth-2:
 jl:
   prefix: jl-test
   stackNameNoDash: JlTestIntegration
+  buckets:
+    private:
+      name: jl-test-integration-private
+      type: private
+    protected:
+      name: jl-test-integration-protected
+      type: protected
+    public:
+      name: jl-test-integration-public
+      type: public
+    protected-2:
+      name: jl-test-integration-protected-2
+      type: protected
+    shared-2:
+      name: rvl-internal
+      type: shared

--- a/example/iam/config.yml
+++ b/example/iam/config.yml
@@ -50,6 +50,22 @@ lf:
 
 jl:
   prefix: jl-test-integration
+  buckets:
+    private:
+      name: jl-test-integration-private
+      type: private
+    protected:
+      name: jl-test-integration-protected
+      type: protected
+    public:
+      name: jl-test-integration-public
+      type: public
+    protected-2:
+      name: jl-test-integration-protected-2
+      type: protected
+    shared-2:
+      name: rvl-internal
+      type: shared
 
 kk-deploy-uat:
   prefix: kk-test-uat

--- a/example/spec/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -21,7 +21,7 @@ const filesTableName = (stackName) => `${stackName}-FilesTable`;
 async function findProtectedBucket(systemBucket, stackName) {
   const bucketConfigs = await s3().getObject({
     Bucket: systemBucket,
-    Key: `${stackName}/workflow/buckets.json`
+    Key: `${stackName}/workflows/buckets.json`
   }).promise()
     .then((response) => response.Body.toString())
     .then((bucketsConfigString) => JSON.parse(bucketsConfigString))

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -7,7 +7,6 @@ const log = require('@cumulus/common/log');
 const handle = require('../lib/response').handle;
 const Search = require('../es/search').Search;
 const models = require('../models');
-const { moveGranuleFiles } = require('@cumulus/ingest/granule');
 
 /**
  * List all granules for a given collection.
@@ -57,9 +56,7 @@ async function put(event) {
     else if (action === 'move') {
       const destinations = body.destinations;
       const distEndpoint = process.env.distEndpoint;
-
-      await moveGranuleFiles(response.files, destinations, distEndpoint);
-
+      await g.move(response, destinations, distEndpoint);
       return {
         granuleId: response.granuleId,
         action,

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -102,7 +102,7 @@ async function createReconciliationReport(params) {
   // Fetch the bucket names to reconcile
   const bucketsConfigJson = await s3().getObject({
     Bucket: systemBucket,
-    Key: `${stackName}/workflow/buckets.json`
+    Key: `${stackName}/workflows/buckets.json`
   }).promise()
     .then((response) => response.Body.toString());
   const dataBuckets = Object.values(JSON.parse(bucketsConfigJson))

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -102,7 +102,7 @@ class Granule extends Manager {
    *    regex - regex for matching filepath of file to new destination
    *    bucket - aws bucket of the destination
    *    filepath - file path/directory on the bucket for the destination
-   * @param {string} distEndpoint - the collection ID
+   * @param {string} distEndpoint - distribution endpoint
    * @returns {Promise<undefined>} undefined
    */
   async move(g, destinations, distEndpoint) {

--- a/packages/api/tests/lambdas/create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/create-reconciliation-report.js
@@ -33,7 +33,7 @@ function storeBucketsConfigToS3(buckets, systemBucket, stackName) {
   });
   return aws.s3().putObject({
     Bucket: systemBucket,
-    Key: `${stackName}/workflow/buckets.json`,
+    Key: `${stackName}/workflows/buckets.json`,
     Body: JSON.stringify(bucketsConfig)
   }).promise();
 }

--- a/packages/api/tests/test_migrations.js
+++ b/packages/api/tests/test_migrations.js
@@ -32,6 +32,7 @@ test.after.always(async () => {
   await recursivelyDeleteS3Bucket(process.env.internal);
   await models.Manager.deleteTable(granulesTable);
   await models.Manager.deleteTable(executionsTable);
+  await esClient.indices.delete({ index: esIndex });
 });
 
 test.serial('Run migrations the first time, it should run', async (t) => {

--- a/packages/deployment/lib/message.js
+++ b/packages/deployment/lib/message.js
@@ -191,7 +191,7 @@ async function generateTemplates(config, outputs, uploader) {
     await uploader(bucket, `${stack}/workflows/list.json`, JSON.stringify(workflows));
 
     // upload the buckets config
-    await uploader(bucket, `${stack}/workflow/buckets.json`, JSON.stringify(config.buckets));
+    await uploader(bucket, `${stack}/workflows/buckets.json`, JSON.stringify(config.buckets));
   }
 }
 

--- a/packages/ingest/cmr.js
+++ b/packages/ingest/cmr.js
@@ -10,6 +10,7 @@ const log = require('@cumulus/common/log');
  * @param {Object} cmrFile - an object representing the cmr file
  * @param {string} cmrFile.granuleId - the granuleId of the cmr xml File
  * @param {string} cmrFile.filename - the s3 uri to the cmr xml file
+ * @param {string} cmrFile.metadata - granule xml document
  * @param {Object} creds - credentials needed to post to the CMR
  * @param {string} creds.provider - the name of the Provider used on the CMR side
  * @param {string} creds.clientId - the clientId used to generate CMR token

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -643,19 +643,20 @@ async function updateMetadata(granuleId, cmrFile, files, distEndpoint, published
     bucketsObject = JSON.parse(bucketsString.Body);
   }
 
+  // URLs are added/updated only for public and protected files
   const bucketKeys = Object.keys(bucketsObject);
   files.forEach((file) => {
     const urlObj = {};
     const bucketkey = bucketKeys.find((bucketKey) =>
-      file.bucket.match(bucketsObject[bucketKey].name));
+      file.bucket === bucketsObject[bucketKey].name);
 
-    if (bucketsObject[bucketkey].type.match('protected')) {
+    if (bucketsObject[bucketkey].type === 'protected') {
       const extension = urljoin(bucketsObject[bucketkey].name, `${file.filepath}`);
       urlObj.URL = urljoin(distEndpoint, extension);
       urlObj.URLDescription = 'File to download';
       urls.push(urlObj);
     }
-    else if (bucketsObject[bucketkey].type.match('public')) {
+    else if (bucketsObject[bucketkey].type === 'public') {
       urlObj.URL = `https://${bucketsObject[bucketkey].name}.s3.amazonaws.com/${file.filepath}`;
       urlObj.URLDescription = 'File to download';
       urls.push(urlObj);
@@ -742,7 +743,8 @@ async function moveGranuleFile(source, target, options) {
  * move granule files from one s3 location to another
  *
  * @param {string} granuleId - granuleiId
- * @param {Array<Object>} sourceFiles - array of file objects
+ * @param {Array<Object>} sourceFiles - array of file objects, they are updated with destination
+ * location after the files are moved
  * @param {string} sourceFiles.name - file name
  * @param {string} sourceFiles.bucket - current bucket of file
  * @param {string} sourceFiles.filepath - current s3 key of file

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -800,9 +800,12 @@ async function moveGranuleFiles(granuleId, sourceFiles, destinations, distEndpoi
   await Promise.all(moveFileRequests);
 
   // update cmr metadata with new file urls
-  const xmlFile = sourceFiles.filter((file) => file.name.endsWith('cmr.xml'));
+  const xmlFile = sourceFiles.filter((file) => file.name.endsWith('.cmr.xml'));
   if (xmlFile.length === 1) {
     return updateMetadata(granuleId, xmlFile[0], sourceFiles, distEndpoint, published);
+  }
+  else if (xmlFile.length > 1) {
+    log.error('more than one .cmr.xml found');
   }
   return Promise.resolve();
 }

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const deprecate = require('depd')('my-module');
-const aws = require('@cumulus/common/aws');
-const { getS3Object, promiseS3Upload } = require('@cumulus/common/aws');
 const fs = require('fs-extra');
 const cloneDeep = require('lodash.clonedeep');
 const get = require('lodash.get');
@@ -15,14 +13,16 @@ const urljoin = require('url-join');
 const encodeurl = require('encodeurl');
 const cksum = require('cksum');
 const checksum = require('checksum');
+const xml2js = require('xml2js');
+const aws = require('@cumulus/common/aws');
+const log = require('@cumulus/common/log');
 const errors = require('@cumulus/common/errors');
+const { xmlParseOptions } = require('@cumulus/cmrjs/utils');
 const { sftpMixin } = require('./sftp');
 const { ftpMixin } = require('./ftp');
 const { httpMixin } = require('./http');
 const { s3Mixin } = require('./s3');
 const { baseProtocol } = require('./protocol');
-const xml2js = require('xml2js');
-const { xmlParseOptions } = require('@cumulus/cmrjs/utils');
 const { publish } = require('./cmr');
 
 let bucketsObject;
@@ -593,7 +593,7 @@ async function getMetadata(xmlFilePath) {
   // GET the metadata text
   // Currently, only supports files that are stored on S3
   const parts = xmlFilePath.match(/^s3:\/\/(.+?)\/(.+)$/);
-  const obj = await getS3Object(parts[1], parts[2]);
+  const obj = await aws.getS3Object(parts[1], parts[2]);
   return obj.Body.toString();
 }
 
@@ -613,7 +613,7 @@ async function parseXmlString(xml) {
 }
 
 async function postS3Object(destination, options) {
-  await promiseS3Upload(
+  await aws.promiseS3Upload(
     { Bucket: destination.bucket, Key: destination.key, Body: destination.body }
   );
   if (options) {
@@ -623,19 +623,18 @@ async function postS3Object(destination, options) {
 }
 
 /**
- * updates cmrFile metadata for any files being moved
+ * updates cmr xml file with updated file urls
  *
- * @param {Object} cmrFile - cmrFile to be updated
- * @param {Object[]} sourceFiles - array of file objects
- * @param {Object[]} destinations - array of objects defining the destination of granule files
+ * @param {string} granuleId - granuleId
+ * @param {Object} cmrFile - cmr xml file to be updated
+ * @param {Object[]} files - array of file objects
  * @param {string} distEndpoint - distribution enpoint from config
+ * @param {boolean} published - indicate if publish is needed
  * @returns {Promise} returns promise to upload updated cmr file
  */
-async function updateMetadata(cmrFile, sourceFiles, destinations, distEndpoint) {
+async function updateMetadata(granuleId, cmrFile, files, distEndpoint, published) {
+  log.debug(`granules.updateMetadata granuleId ${granuleId}, xml file ${cmrFile.filename}`);
   const urls = [];
-  const file = cmrFile.file;
-  const destination = cmrFile.destination;
-
   if (!bucketsObject) {
     const bucketsString = await aws.s3().getObject({
       Bucket: process.env.bucket,
@@ -645,33 +644,24 @@ async function updateMetadata(cmrFile, sourceFiles, destinations, distEndpoint) 
   }
 
   const bucketKeys = Object.keys(bucketsObject);
-  sourceFiles.forEach((sourceFile) => {
+  files.forEach((file) => {
     const urlObj = {};
-    const currDestination = destinations.find((dest) => sourceFile.name.match(dest.regex));
-    let key;
-    let filepath;
-    if (currDestination) {
-      key =
-        bucketKeys.find((bucketKey) => currDestination.bucket.match(bucketsObject[bucketKey].name));
-      filepath = currDestination.filepath;
-    }
-    else {
-      key = bucketKeys.find((bucketKey) => sourceFile.bucket.match(bucketsObject[bucketKey].name));
-      filepath = sourceFile.filepath;
-    }
-    if (bucketsObject[key].type.match('protected')) {
-      const extension = urljoin(bucketsObject[key].name, `${filepath}/${sourceFile.name}`);
+    const bucketkey = bucketKeys.find((bucketKey) =>
+      file.bucket.match(bucketsObject[bucketKey].name));
+
+    if (bucketsObject[bucketkey].type.match('protected')) {
+      const extension = urljoin(bucketsObject[bucketkey].name, `${file.filepath}`);
       urlObj.URL = urljoin(distEndpoint, extension);
       urlObj.URLDescription = 'File to download';
       urls.push(urlObj);
     }
-    else if (bucketsObject[key].type.match('public')) {
-      urlObj.URL = `https://${bucketsObject[key].name}.s3.amazonaws.com/${filepath}/${sourceFile.name}`;
+    else if (bucketsObject[bucketkey].type.match('public')) {
+      urlObj.URL = `https://${bucketsObject[bucketkey].name}.s3.amazonaws.com/${file.filepath}`;
       urlObj.URLDescription = 'File to download';
       urls.push(urlObj);
     }
   });
-  const metadata = await getMetadata(file.filename);
+  const metadata = await getMetadata(cmrFile.filename);
   const metadataObject = await parseXmlString(metadata);
   const metadataGranule = get(metadataObject, 'Granule');
   const updatedGranule = {};
@@ -694,26 +684,13 @@ async function updateMetadata(cmrFile, sourceFiles, destinations, distEndpoint) 
     password: process.env.cmr_password
   };
 
-  const response = await publish(file, creds, process.env.bucket, process.env.stackName);
-  if (response) {
-    let action;
-    if (destination) {
-      const options = {
-        Bucket: file.bucket,
-        Key: file.filepath
-      };
-      const target = {
-        bucket: destination.bucket,
-        key: `${destination.filepath}/${file.name}`,
-        body: xml
-      };
-      action = await postS3Object(target, options);
-    }
-    else {
-      action = await postS3Object({ bucket: file.bucket, key: file.filepath, body: xml });
-    }
-    return action;
-  }
+  const cmrFileObject = {
+    filename: cmrFile.filename,
+    metadata: xml,
+    granuleId: granuleId
+  };
+  if (published) await publish(cmrFileObject, creds, process.env.bucket, process.env.stackName);
+  return postS3Object({ bucket: cmrFile.bucket, key: cmrFile.filepath, body: xml });
 }
 
 /**
@@ -764,43 +741,55 @@ async function moveGranuleFile(source, target, options) {
 /**
  * move granule files from one s3 location to another
  *
- * @param {Object[]} sourceFiles - array of file objects
- * @param {string} sourceFiles[].name - file name
- * @param {string} sourceFiles[].bucket - current bucket of file
- * @param {string} sourceFiles[].filepath - current bucket location of file
+ * @param {string} granuleId - granuleiId
+ * @param {Array<Object>} sourceFiles - array of file objects
+ * @param {string} sourceFiles.name - file name
+ * @param {string} sourceFiles.bucket - current bucket of file
+ * @param {string} sourceFiles.filepath - current s3 key of file
  * @param {Object[]} destinations - array of objects defining the destination of granule files
- * @param {string} destinations[].regex - regex for matching filepath of file to new destination
- * @param {string} destinations[].bucket - aws bucket
- * @param {string} destinations[].key - filepath on the bucket for the destination
+ * @param {string} destinations.regex - regex for matching filepath of file to new destination
+ * @param {string} destinations.bucket - aws bucket of the destination
+ * @param {string} destinations.filepath - file path/directory on the bucket for the destination
  * @param {string} distEndpoint - distribution enpoint from config
+ * @param {boolean} published - indicate if publish is needed
  * @returns {Promise<undefined>} returns `undefined` when all the files are moved
  */
-async function moveGranuleFiles(sourceFiles, destinations, distEndpoint) {
+async function moveGranuleFiles(granuleId, sourceFiles, destinations, distEndpoint, published) {
   const moveFileRequests = sourceFiles.map((file) => {
     const destination = destinations.find((dest) => file.name.match(dest.regex));
 
-    if (file.name.match(/.*\.cmr\.xml$/)) {
-      return updateMetadata(
-        { file, destination }, sourceFiles, destinations, distEndpoint
-      );
-    }
     // if there's no match, we skip the file
-    else if (destination) {
+    if (destination) {
+      const parsed = aws.parseS3Uri(file.filename);
       const source = {
-        Bucket: file.bucket,
-        Key: file.filepath
+        Bucket: parsed.Bucket,
+        Key: parsed.Key
       };
 
       const target = {
         Bucket: destination.bucket,
-        Key: `${destination.filepath}/${file.name}`
+        Key: urljoin(destination.filepath, file.name)
       };
 
-      return moveGranuleFile(source, target);
+      log.debug('moveGranuleFiles', source, target);
+      return moveGranuleFile(source, target).then(() => { /* eslint-disable no-param-reassign */
+        // update the granule file location in source file
+        file.bucket = target.Bucket;
+        file.filepath = target.Key;
+        file.filename = aws.buildS3Uri(file.bucket, file.filepath);
+      });
     }
+    return Promise.resolve();
   });
 
-  return Promise.all(moveFileRequests);
+  await Promise.all(moveFileRequests);
+
+  // update cmr metadata with new file urls
+  const xmlFile = sourceFiles.filter((file) => file.name.endsWith('cmr.xml'));
+  if (xmlFile.length === 1) {
+    return updateMetadata(granuleId, xmlFile[0], sourceFiles, distEndpoint, published);
+  }
+  return {};
 }
 
 module.exports.selector = selector;

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -757,9 +757,7 @@ async function moveGranuleFile(source, target, options) {
  */
 async function moveGranuleFiles(granuleId, sourceFiles, destinations, distEndpoint, published) {
   const moveFileRequests = sourceFiles.map((file) => {
-    console.log('file', file);
     const destination = destinations.find((dest) => file.name.match(dest.regex));
-    console.log('destination', destination);
     const parsed = aws.parseS3Uri(file.filename);
     // if there's no match, we skip the file
     if (destination) {

--- a/packages/ingest/test/granule.js
+++ b/packages/ingest/test/granule.js
@@ -4,7 +4,7 @@ const test = require('ava');
 const discoverPayload = require('@cumulus/test-data/payloads/new-message-schema/discover.json');
 const ingestPayload = require('@cumulus/test-data/payloads/new-message-schema/ingest.json');
 const { randomString } = require('@cumulus/common/test-utils');
-const { s3 } = require('@cumulus/common/aws');
+const { buildS3Uri, s3 } = require('@cumulus/common/aws');
 
 const {
   selector,
@@ -275,9 +275,12 @@ test('moveGranuleFiles moves granule files between s3 locations', async (t) => {
   ];
 
   const sourceFilePromises = filenames.map(async (name) => {
-    const params = { Bucket: bucket, Key: `origin/${name}`, Body: name };
+    const sourcefilePath = `origin/${name}`;
+    const params = { Bucket: bucket, Key: sourcefilePath, Body: name };
     await s3().putObject(params).promise();
-    return { name, bucket, filepath: `origin/${name}` };
+    return {
+      name, bucket, filepath: sourcefilePath, filename: buildS3Uri(bucket, sourcefilePath)
+    };
   });
 
   const destinationFilepath = 'destination';
@@ -332,9 +335,12 @@ test('moveGranuleFiles only moves granule files specified with regex', async (t)
   ];
 
   const sourceFilePromises = filenames.map(async (name) => {
-    const params = { Bucket: bucket, Key: `origin/${name}`, Body: name };
+    const sourcefilePath = `origin/${name}`;
+    const params = { Bucket: bucket, Key: sourcefilePath, Body: name };
     await s3().putObject(params).promise();
-    return { name, bucket, filepath: `origin/${name}` };
+    return {
+      name, bucket, filepath: sourcefilePath, filename: buildS3Uri(bucket, sourcefilePath)
+    };
   });
 
   const destinationFilepath = 'destination';

--- a/packages/ingest/test/granule.js
+++ b/packages/ingest/test/granule.js
@@ -304,7 +304,7 @@ test('moveGranuleFiles moves granule files between s3 locations', async (t) => {
   ];
 
   const sourceFiles = await Promise.all(sourceFilePromises);
-  await moveGranuleFiles(sourceFiles, destinations);
+  await moveGranuleFiles(randomString(), sourceFiles, destinations);
 
   await s3().listObjects({ Bucket: bucket }).promise().then((list) => {
     t.is(list.Contents.length, 2);
@@ -354,7 +354,7 @@ test('moveGranuleFiles only moves granule files specified with regex', async (t)
   ];
 
   const sourceFiles = await Promise.all(sourceFilePromises);
-  await moveGranuleFiles(sourceFiles, destinations);
+  await moveGranuleFiles(randomString(), sourceFiles, destinations);
 
   await s3().listObjects({ Bucket: bucket }).promise().then((list) => {
     t.is(list.Contents.length, 1);


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-746: Update granule record in Dynamo after moving it via api](https://bugs.earthdata.nasa.gov/browse/CUMULUS-746)

## Changes

* Move granule API correctly updates record in dynamo DB and cmr xml file

## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [x ] Adhoc testing: Tested on AWS
- [x ] Update CHANGELOG
- [x ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
