### PR TITLE
CUMULUS-710 retry configuration tests

### DIFF
--- a/example/spec/retryConfiguration/retryConfiguration.js
+++ b/example/spec/retryConfiguration/retryConfiguration.js
@@ -1,0 +1,100 @@
+const { buildAndExecuteWorkflow, LambdaStep } = require('@cumulus/integration-tests');
+const { loadConfig } = require('../helpers/testUtils');
+
+const awsConfig = loadConfig();
+const lambdaStep = new LambdaStep();
+
+/**
+ * For multiple executions of a step, get the time intervals at which retries
+ * were scheduled
+ *
+ * @param {List<Object>} executions - the executions of the lambda
+ * @returns {List<Integer>} - list of seconds between retries
+ */
+function getRetryIntervals(executions) {
+  let i;
+  const retryIntervals = [];
+
+  for (i = 1; i < executions.length; i += 1) {
+    const intervalSeconds = (
+      executions[i].scheduleEvent.timestamp - executions[i - 1].completeEvent.timestamp
+    ) / 1000;
+    retryIntervals.push(Math.round(intervalSeconds));
+  }
+
+  return retryIntervals;
+}
+
+describe('When a task is configured to retry', () => {
+  let workflowExecution = null;
+  process.env.ExecutionsTable = `${awsConfig.stackName}-ExecutionsTable`;
+  let lambdaExecutions = null;
+
+  beforeAll(async () => {
+    workflowExecution = await buildAndExecuteWorkflow(
+      awsConfig.stackName,
+      awsConfig.bucket,
+      'RetryPassWorkflow'
+    );
+
+    lambdaExecutions = await lambdaStep.getStepExecutions(workflowExecution.executionArn, 'HelloWorld');
+  });
+
+  describe('and it fails', () => {
+    it('Cumulus retries it', () => {
+      expect(lambdaExecutions.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('and it succeeds', () => {
+    it('Cumulus continues the workflow', () => {
+      expect(workflowExecution.status).toEqual('SUCCEEDED');
+    });
+  });
+});
+
+describe('When a task is not configured to retry', () => {
+  let workflowExecution = null;
+
+  beforeAll(async () => {
+    workflowExecution = await buildAndExecuteWorkflow(
+      awsConfig.stackName,
+      awsConfig.bucket,
+      'HelloWorldFailWorkflow'
+    );
+  });
+
+  it('Cumulus fails the workflow', () => {
+    expect(workflowExecution.status).toEqual('FAILED');
+  });
+});
+
+describe('When a task is configured to retry', () => {
+  let workflowExecution = null;
+  let lambdaExecutions = null;
+  let retryIntervals = [];
+
+  beforeAll(async () => {
+    workflowExecution = await buildAndExecuteWorkflow(
+      awsConfig.stackName,
+      awsConfig.bucket,
+      'RetryFailWorkflow'
+    );
+
+    lambdaExecutions = await lambdaStep.getStepExecutions(workflowExecution.executionArn, 'HelloWorld');
+    retryIntervals = getRetryIntervals(lambdaExecutions);
+  });
+
+  describe('a specific number of times', () => {
+    it('and it fails that number of times, Cumulus stops retrying it and fails the workflow', () => {
+      expect(workflowExecution.status).toEqual('FAILED');
+      expect(lambdaExecutions.length).toEqual(4);
+    });
+  });
+
+  describe('with a backoff', () => {
+    it('and it fails, Cumulus retries it with the configured backoff time', () => {
+      expect(retryIntervals).toEqual([2, 4, 8]);
+    });
+  });
+});

--- a/example/workflows.yml
+++ b/example/workflows.yml
@@ -1,3 +1,127 @@
+RetryPassWorkflow:
+  Comment: 'Tests Retry Configurations'
+  StartAt: StartStatus
+  States:
+    StartStatus:
+      Type: Task
+      Resource: ${SfSnsReportLambdaFunction.Arn}
+      CumulusConfig:
+        cumulus_message:
+          input: '{$}'
+      Next: HelloWorld
+    HelloWorld:
+      CumulusConfig:
+        fail: true
+        passOnRetry: true
+      Type: Task
+      Resource: ${HelloWorldLambdaFunction.Arn}
+      Next: StopStatus
+      Retry:
+          - ErrorEquals:
+              - States.ALL
+            IntervalSeconds: 2
+            MaxAttempts: 3
+    StopStatus:
+      Type: Task
+      Resource: ${SfSnsReportLambdaFunction.Arn}
+      CumulusConfig:
+        sfnEnd: true
+        stack: '{$.meta.stack}'
+        bucket: '{$.meta.buckets.internal.name}'
+        stateMachine: '{$.cumulus_meta.state_machine}'
+        executionName: '{$.cumulus_meta.execution_name}'
+        cumulus_message:
+          input: '{$}'
+      Catch:
+        - ErrorEquals:
+          - States.ALL
+          Next: WorkflowFailed
+      End: true
+    WorkflowFailed:
+      Type: Fail
+      Cause: 'Workflow failed'
+
+HelloWorldFailWorkflow:
+  Comment: 'Failing Hello World Workflow'
+  StartAt: StartStatus
+  States:
+    StartStatus:
+      Type: Task
+      Resource: ${SfSnsReportLambdaFunction.Arn}
+      CumulusConfig:
+        cumulus_message:
+          input: '{$}'
+      Next: HelloWorld
+    HelloWorld:
+      CumulusConfig:
+        fail: true
+      Type: Task
+      Resource: ${HelloWorldLambdaFunction.Arn}
+      Next: StopStatus
+    StopStatus:
+      Type: Task
+      Resource: ${SfSnsReportLambdaFunction.Arn}
+      CumulusConfig:
+        sfnEnd: true
+        stack: '{$.meta.stack}'
+        bucket: '{$.meta.buckets.internal.name}'
+        stateMachine: '{$.cumulus_meta.state_machine}'
+        executionName: '{$.cumulus_meta.execution_name}'
+        cumulus_message:
+          input: '{$}'
+      Catch:
+        - ErrorEquals:
+          - States.ALL
+          Next: WorkflowFailed
+      End: true
+    WorkflowFailed:
+      Type: Fail
+      Cause: 'Workflow failed'
+
+RetryFailWorkflow:
+  Comment: 'Tests Retries and Fail'
+  StartAt: StartStatus
+  States:
+    StartStatus:
+      Type: Task
+      Resource: ${SfSnsReportLambdaFunction.Arn}
+      CumulusConfig:
+        cumulus_message:
+          input: '{$}'
+      Next: HelloWorld
+    HelloWorld:
+      CumulusConfig:
+        fail: true
+      Type: Task
+      Resource: ${HelloWorldLambdaFunction.Arn}
+      Next: StopStatus
+      Retry:
+          - ErrorEquals:
+              - States.ALL
+            IntervalSeconds: 2
+            BackoffRate: 2
+            MaxAttempts: 3
+    StopStatus:
+      Type: Task
+      Resource: ${SfSnsReportLambdaFunction.Arn}
+      CumulusConfig:
+        sfnEnd: true
+        stack: '{$.meta.stack}'
+        bucket: '{$.meta.buckets.internal.name}'
+        stateMachine: '{$.cumulus_meta.state_machine}'
+        executionName: '{$.cumulus_meta.execution_name}'
+        cumulus_message:
+          input: '{$}'
+      Catch:
+        - ErrorEquals:
+          - States.ALL
+          Next: WorkflowFailed
+      End: true
+    WorkflowFailed:
+      Type: Fail
+      Cause: 'Workflow failed'
+
+
 HelloWorldWorkflow:
   Comment: 'Returns Hello World'
   StartAt: StartStatus

--- a/packages/integration-tests/sfnStep.js
+++ b/packages/integration-tests/sfnStep.js
@@ -38,15 +38,39 @@ class SfnStep {
   }
 
   /**
+   * Get the information for an instance of a step execution. Get the schedule, start, 
+   * and complete event.
+   *
+   * @param {Object} executionHistory - AWS Step Function execution history
+   * @param {Object} scheduleEvent    - AWS Step Function schedule-type event
+   * @returns {Object} object containing a schedule event, start event, and complete
+   * event if exists for each execution of the step, null if cannot find the step
+   */
+  getStepExecutionInstance(executionHistory, scheduleEvent) {
+    let startEvent = null;
+    let completeEvent = null;
+
+    if (scheduleEvent.type !== this.startFailedEvent) {
+      startEvent = this.getStartEvent(executionHistory, scheduleEvent, this);
+
+      if (startEvent !== null && startEvent.type !== this.startFailedEvent) {
+        completeEvent = this.getCompletionEvent(executionHistory, startEvent, this);
+      }
+    }
+
+    return { scheduleEvent, startEvent, completeEvent };
+  }
+
+  /**
    * Get the events for the step execution for the given workflow execution.
    * This function currently assumes one execution of the given step (by step name) per workflow.
    *
    * @param {string} workflowExecutionArn - Arn of the workflow execution
    * @param {string} stepName - name of the step
-   * @returns {Object} an object containing a schedule event, start event, and complete
-   * event if exist, null if cannot find the step
+   * @returns {List<Object>} objects containing a schedule event, start event, and complete
+   * event if exists for each execution of the step, null if cannot find the step
    */
-  async getStepExecution(workflowExecutionArn, stepName) {
+  async getStepExecutions(workflowExecutionArn, stepName) {
     const executionHistory = (
       await sfn().getExecutionHistory({ executionArn: workflowExecutionArn }).promise()
     );
@@ -64,25 +88,7 @@ class SfnStep {
       return null;
     }
 
-    // use last event and discard the failed ones
-    // if it is activity get the last item otherwise the first
-    let scheduleEvent = scheduleEvents[0];
-    if (this.classType === 'activity') {
-      scheduleEvent = scheduleEvents[scheduleEvents.length - 1];
-    }
-
-    let startEvent = null;
-    let completeEvent = null;
-
-    if (scheduleEvent.type !== this.startFailedEvent) {
-      startEvent = this.getStartEvent(executionHistory, scheduleEvent, this);
-
-      if (startEvent !== null && startEvent.type !== this.startFailedEvent) {
-        completeEvent = this.getCompletionEvent(executionHistory, startEvent, this);
-      }
-    }
-
-    return { scheduleEvent, startEvent, completeEvent };
+    return scheduleEvents.map((e) => this.getStepExecutionInstance(executionHistory, e));
   }
 
   /**
@@ -93,12 +99,15 @@ class SfnStep {
    * @returns {Object} object containing the payload, null if error
    */
   async getStepOutput(workflowExecutionArn, stepName) {
-    const stepExecution = await this.getStepExecution(workflowExecutionArn, stepName, this);
+    const stepExecutions = await this.getStepExecutions(workflowExecutionArn, stepName, this);
 
-    if (stepExecution === null) {
+    if (stepExecutions === null) {
       console.log(`Could not find step ${stepName} in execution.`);
       return null;
     }
+
+    // Use the last execution in case of a fail/retry situation
+    const stepExecution = stepExecutions[stepExecutions.length - 1];
 
     if (stepExecution.completeEvent === null ||
         stepExecution.completeEvent.type !== this.successEvent) {

--- a/tasks/hello-world/index.js
+++ b/tasks/hello-world/index.js
@@ -1,8 +1,30 @@
 'use strict';
 
 const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
+const { log } = require('@cumulus/common');
 
 /* eslint-disable no-unused-vars */
+
+let passOnRetry = false;
+
+/**
+ * Throw an error if hello world is configured to throw an error for
+ * testing/example purposes. Set the pass on retry value to simulate
+ * a task passing on a retry.
+ *
+ * @param {Object} event - input from the message adapter
+ * @returns {undefined} none
+ */
+function throwErrorIfConfigured(event) {
+  if (passOnRetry) {
+    log.debug('Detected retry');
+    passOnRetry = false;
+  }
+  else if (event.config.fail) {
+    passOnRetry = event.config.passOnRetry;
+    throw new Error('Step configured to force fail');
+  }
+}
 
 /**
 * Return sample 'hello world' JSON
@@ -11,6 +33,8 @@ const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 * @returns {Object} sample JSON object
 */
 function helloWorld(event) {
+  throwErrorIfConfigured(event);
+
   return { hello: 'Hello World' };
 }
 /**

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -40,6 +40,7 @@
     "@cumulus/cumulus-message-adapter-js": "^1.0.1"
   },
   "devDependencies": {
+    "@cumulus/common": "^1.6.0",
     "ava": "^0.25.0",
     "nyc": "^11.6.0",
     "proxyquire": "^2.0.0",

--- a/tasks/hello-world/schemas/config.json
+++ b/tasks/hello-world/schemas/config.json
@@ -1,0 +1,15 @@
+{
+  "title": "HelloWorldConfig",
+  "description": "Describes the configuration the hello-world task",
+  "type": "object",
+  "properties": {
+    "fail": {
+      "type": "boolean",
+      "description": "true to throw an error for the task, failing the task"
+    },
+    "passOnRetry": {
+      "type": "boolean", 
+      "description": "If configured to fail, true to pass (not throw an error) when retried"
+    }
+  }
+}

--- a/tasks/test-processing/README.md
+++ b/tasks/test-processing/README.md
@@ -1,0 +1,15 @@
+# @cumulus/test-processing
+
+[![CircleCI](https://circleci.com/gh/cumulus-nasa/cumulus.svg?style=svg)](https://circleci.com/gh/cumulus-nasa/cumulus)
+
+Fake processing task to be used for integration tests.
+
+## What is Cumulus?
+
+Cumulus is a cloud-based data ingest, archive, distribution and management prototype for NASA's future Earth science data streams.
+
+[Cumulus Documentation](https://cumulus-nasa.github.io/)
+
+## Contributing
+
+See [Cumulus README](https://github.com/cumulus-nasa/cumulus/blob/master/README.md#installing-and-deploying)


### PR DESCRIPTION
**Summary:** Integration test for retry configuration

Addresses [CUMULUS-710](https://bugs.earthdata.nasa.gov/browse/CUMULUS-710)

## Changes

Tests for the following acceptance criteria:

- When a task is configured to retry and it fails, Cumulus retries it
- When a task is configured to retry and it succeeds, Cumulus continues the workflow
- When a task is not configured to retry and it fails, Cumulus fails the workflow
- When a task is configured to retry with a backoff and it fails, Cumulus retries it with the configured backoff time
- When a task is configured to retry a specific number of times and it fails that number of times, Cumulus stops retrying it and fails the workflow

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
