### PR TITLE
CUMULUS-760 Add ability to query the API from integration tests

### DIFF
--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -185,6 +185,9 @@ mth-2:
     protected:
       name: '{{prefix}}-protected'
       type: protected
+    protected-2:
+      name: '{{prefix}}-protected'
+      type: protected
     public:
       name: '{{prefix}}-public'
       type: public

--- a/example/spec/config.yml
+++ b/example/spec/config.yml
@@ -4,6 +4,17 @@ bucket: cumulus-test-sandbox-internal
 distributionEndpoint: https://example.com/
 ems_provider: CUMULUS
 IngestGranule:
+  IngestGranuleOutput:
+    granules:
+      - files:
+        - bucket: cumulus-test-sandbox-protected
+          filename: "s3://cumulus-test-sandbox-protected/MOD09GQ/2017/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf"
+        - bucket: cumulus-test-sandbox-private
+          filename: "s3://cumulus-test-sandbox-private/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met"
+        - bucket: cumulus-test-sandbox-public
+          filename: "s3://cumulus-test-sandbox-public/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg"
+        - bucket: cumulus-test-sandbox-protected-2
+          filename: "s3://cumulus-test-sandbox-protected-2/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml"
   SyncGranuleOutput:
     granules:
       - files:

--- a/example/spec/ingestGranule/IngestGranule.output.payload.template.json
+++ b/example/spec/ingestGranule/IngestGranule.output.payload.template.json
@@ -8,8 +8,8 @@
       "files": [
         {
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
-          "bucket": "cumulus-test-sandbox-protected",
-          "filename": "s3://cumulus-test-sandbox-protected/MOD09GQ/2017/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
+          "bucket": "this-should-be-replaced-with-protected-bucket-name-in-the-test",
+          "filename": "s3://this-should-be-replaced-with-protected-bucket-name-in-the-test/MOD09GQ/2017/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
           "fileSize": 17865615,
           "path": "cumulus-test-data/pdrs",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}",
@@ -17,8 +17,8 @@
         },
         {
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
-          "bucket": "cumulus-test-sandbox-private",
-          "filename": "s3://cumulus-test-sandbox-private/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
+          "bucket": "this-should-be-replaced-with-private-bucket-name-in-the-test",
+          "filename": "s3://this-should-be-replaced-with-private-bucket-name-in-the-test/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
           "fileSize": 44118,
           "path": "cumulus-test-data/pdrs",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{substring(file.name, 0, 3)}",
@@ -26,17 +26,17 @@
         },
         {
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
-          "bucket": "cumulus-test-sandbox-public",
-          "filename": "s3://cumulus-test-sandbox-public/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
+          "bucket": "this-should-be-replaced-with-public-bucket-name-in-the-test",
+          "filename": "s3://this-should-be-replaced-with-public-bucket-name-in-the-test/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
           "fileSize": 44118,
           "path": "cumulus-test-data/pdrs",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{substring(file.name, 0, 3)}",
           "filepath": "MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg"
         },
         {
-          "filename": "s3://cumulus-test-sandbox-protected-2/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
+          "filename": "s3://this-should-be-replaced-with-protected-2-bucket-name-in-the-test/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{substring(file.name, 0, 3)}",
-          "bucket": "cumulus-test-sandbox-protected-2",
+          "bucket": "this-should-be-replaced-with-protected-2-bucket-name-in-the-test",
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "filepath": "MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml"
         }

--- a/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1,7 +1,12 @@
+'use strict';
+
 const fs = require('fs');
 const urljoin = require('url-join');
 const got = require('got');
-const { Granule, Execution } = require('@cumulus/api/models');
+const {
+  models: { Granule, Execution },
+  testUtils: apiTestUtils
+} = require('@cumulus/api');
 const { s3, s3ObjectExists } = require('@cumulus/common/aws');
 const {
   buildAndExecuteWorkflow,
@@ -15,15 +20,17 @@ const config = loadConfig();
 const lambdaStep = new LambdaStep();
 const taskName = 'IngestGranule';
 
-const syncGranuleOutputFilename = './spec/ingestGranule/SyncGranule.output.payload.template.json';
 const templatedSyncGranuleFilename = templateFile({
-  inputTemplateFilename: syncGranuleOutputFilename,
+  inputTemplateFilename: './spec/ingestGranule/SyncGranule.output.payload.template.json',
   config: config[taskName].SyncGranuleOutput
 });
 const expectedSyncGranulePayload = JSON.parse(fs.readFileSync(templatedSyncGranuleFilename));
 
-const outputPayloadTemplateFilename = './spec/ingestGranule/IngestGranule.output.payload.template.json'; // eslint-disable-line max-len
-const expectedPayload = JSON.parse(fs.readFileSync(outputPayloadTemplateFilename));
+const templatedOutputPayloadFilename = templateFile({
+  inputTemplateFilename: './spec/ingestGranule/IngestGranule.output.payload.template.json',
+  config: config[taskName].IngestGranuleOutput
+});
+const expectedPayload = JSON.parse(fs.readFileSync(templatedOutputPayloadFilename));
 
 describe('The S3 Ingest Granules workflow', () => {
   const inputPayloadFilename = './spec/ingestGranule/IngestGranule.input.payload.json';
@@ -49,6 +56,15 @@ describe('The S3 Ingest Granules workflow', () => {
 
   it('completes execution with success status', () => {
     expect(workflowExecution.status).toEqual('SUCCEEDED');
+  });
+
+  it('makes the granule available through the Cumulus API', async () => {
+    const granule = await apiTestUtils.getGranule({
+      prefix: config.prefix,
+      granuleId: inputPayload.granules[0].granuleId
+    });
+
+    expect(granule.granuleId).toEqual(inputPayload.granules[0].granuleId);
   });
 
   describe('the SyncGranules task', () => {
@@ -86,23 +102,18 @@ describe('The S3 Ingest Granules workflow', () => {
       await s3().deleteObject({ Bucket: files[3].bucket, Key: files[3].filepath }).promise();
     });
 
-    it('has a payload with updated filename', () => {
-      let i;
-      for (i = 0; i < 4; i += 1) {
-        expect(files[i].filename).toEqual(expectedPayload.granules[0].files[i].filename);
-      }
+    it('has a payload with correct buckets and filenames', () => {
+      files.forEach((file) => {
+        const expectedFile = expectedPayload.granules[0].files.find((f) => f.name === file.name);
+        expect(file.filename).toEqual(expectedFile.filename);
+        expect(file.bucket).toEqual(expectedFile.bucket);
+      });
     });
 
     it('moves files to the bucket folder based on metadata', () => {
       existCheck.forEach((check) => {
         expect(check).toEqual(true);
       });
-    });
-
-    it('moves files to separate protected buckets based on configuration', () => {
-      // Above we checked that the files exist, now show that they are in separate protected buckets
-      expect(files[0].bucket).toEqual('cumulus-test-sandbox-protected');
-      expect(files[3].bucket).toEqual('cumulus-test-sandbox-protected-2');
     });
   });
 
@@ -155,7 +166,7 @@ describe('The S3 Ingest Granules workflow', () => {
 
   describe('the sf-sns-report task has published a sns message and', () => {
     it('the granule record is added to DynamoDB', async () => {
-      const record = await granuleModel.get({ granuleId: inputPayload.granules[0].granuleId }); 
+      const record = await granuleModel.get({ granuleId: inputPayload.granules[0].granuleId });
       expect(record.execution).toEqual(getExecutionUrl(workflowExecution.executionArn));
     });
 

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -37,3 +37,6 @@ exports.sfStart = broadcast.start;
 exports.sfEnd = broadcast.end;
 exports.indexer = indexer.handler;
 exports.logHandler = indexer.logHandler;
+
+exports.models = require('./models');
+exports.testUtils = require('./lib/testUtils');

--- a/packages/api/lib/response.js
+++ b/packages/api/lib/response.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-const get = require('lodash.get');
 const log = require('@cumulus/common/log');
 const proxy = require('lambda-proxy-utils');
 const { User } = require('../models');

--- a/packages/api/lib/response.js
+++ b/packages/api/lib/response.js
@@ -35,7 +35,7 @@ function getToken(req) {
 }
 
 
-function resp(context, err, body, status = null, headers = null) {
+function resp(context, err, body, status = null, headers = {}) {
   if (typeof context.succeed !== 'function') {
     throw new Error('context object with succeed method not provided');
   }
@@ -43,20 +43,17 @@ function resp(context, err, body, status = null, headers = null) {
   if (err) {
     log.error(err);
     status = status || 400;
-    const message = get(err, 'message', errorify(err));
-    const detail = get(err, 'detail');
-
     body = {
-      message,
-      detail
+      message: err.message || errorify(err),
+      detail: err.detail
     };
   }
 
   const res = new proxy.Response({ cors: true, statusCode: status });
+
+  Object.keys(headers).forEach((h) => res.set(h, headers[h]));
   res.set('Strict-Transport-Security', 'max-age=31536000');
-  if (headers) {
-    Object.keys(headers).forEach((h) => res.set(h, headers[h]));
-  }
+
   return context.succeed(res.send(body));
 }
 
@@ -71,9 +68,7 @@ function handle(event, context, authCheck, func) {
 
     const token = getToken(req);
 
-    if (!token) {
-      return cb('Invalid Authorization token');
-    }
+    if (!token) return cb('Invalid Authorization token');
 
     // get the user
     const u = new User();
@@ -86,12 +81,8 @@ function handle(event, context, authCheck, func) {
       }
       const obj = results.Items[0];
 
-      if (!obj.expires) {
-        return cb('Invalid Authorization token');
-      }
-      else if (obj.expires < Date.now()) {
-        return cb('Session expired');
-      }
+      if (!obj.expires) return cb('Invalid Authorization token');
+      else if (obj.expires < Date.now()) return cb('Session expired');
       return func(cb);
     }).catch((e) => cb('Invalid Authorization token', e));
   }

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -1,11 +1,107 @@
 'use strict';
 
+const cloneDeep = require('lodash.clonedeep');
 const { randomString } = require('@cumulus/common/test-utils');
+const { aws: { lambda } } = require('@cumulus/common');
+const { User } = require('../models');
+
+/**
+ * Add a user that can be authenticated against
+ *
+ * @param {Object} params - params
+ * @param {User} params.userDbClient - an instance of the Users model
+ * @returns {Promise<Object>} - an object containing a userName and a password
+ */
+async function createFakeUser({ userDbClient }) {
+  // Create the user and token for this request
+  const userName = randomString();
+  const password = randomString();
+
+  await userDbClient.create([
+    {
+      userName,
+      password,
+      expires: Date.now() + (60 * 60 * 1000) // Token expires in 1 hour
+    }
+  ]);
+
+  return { userName, password };
+}
+
+/**
+ * Call the Cumulus API by invoking the Lambda function that backs the API
+ * Gateway endpoint.
+ *
+ * Intended for use with integration tests.  Will invoke the function in AWS
+ * Lambda.  This function will handle authorization of the request.
+ *
+ * @param {Object} params - params
+ * @param {string} params.prefix - the prefix configured for the stack
+ * @param {string} params.functionName - the name of the Lambda function that
+ *   backs the API Gateway endpoint.  Does not include the stack prefix in the
+ *   name.
+ * @param {string} params.payload - the payload to send to the Lambda function.
+ *   See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @returns {Promise<Object>} - the parsed payload of the response.  See
+ *   https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
+ */
+async function callCumulusApi({ prefix, functionName, payload: userPayload }) {
+  const payload = cloneDeep(userPayload);
+
+  const userDbClient = new User(`${prefix}-UsersTable`);
+
+  const { userName, password } = await createFakeUser({ userDbClient });
+
+  // Add authorization header to the request
+  payload.headers = payload.headers || {};
+  payload.headers.Authorization = `Bearer ${password}`;
+
+  let apiOutput;
+  try {
+    apiOutput = await lambda().invoke({
+      Payload: JSON.stringify(payload),
+      FunctionName: `${prefix}-${functionName}`,
+    }).promise();
+  }
+  finally {
+    // Delete the user created for this request
+    await userDbClient.delete({ userName });
+  }
+
+  return JSON.parse(apiOutput.Payload);
+}
+
+/**
+ * Fetch a granule from the Cumulus API
+ *
+ * @param {Object} params - params
+ * @param {string} params.prefix - the prefix configured for the stack
+ * @param {string} params.granuleId - a granule ID
+ * @returns {Promise<Object>} - the granule fetched by the API
+ */
+async function getGranule({ prefix, granuleId }) {
+  const payload = await callCumulusApi({
+    prefix: prefix,
+    functionName: 'ApiGranulesDefault',
+    payload: {
+      httpMethod: 'GET',
+      resource: '/granules/{granuleName}',
+      path: `/granules/${granuleId}`,
+      pathParameters: {
+        granuleName: granuleId
+      }
+    }
+  });
+
+  return JSON.parse(payload.body);
+}
 
 /**
  * mocks the context object of the lambda function with
  * succeed and fail functions to facilitate testing of
  * lambda functions used as backend in ApiGateway
+ *
+ * Intended for use with unit tests.  Will invoke the function locally.
  *
  * @param {Function} endpoint - the lambda function used as ApiGateway backend
  * @param {Object} event - aws lambda event object
@@ -133,6 +229,8 @@ function fakeCollectionFactory() {
 }
 
 module.exports = {
+  callCumulusApi,
+  getGranule,
   testEndpoint,
   fakeGranuleFactory,
   fakePdrFactory,

--- a/packages/api/models/index.js
+++ b/packages/api/models/index.js
@@ -10,8 +10,11 @@ const Execution = require('./executions');
 const FileClass = require('./files');
 
 class User extends Manager {
-  constructor() {
-    super(process.env.UsersTable);
+  constructor(usersTable) {
+    // The usersTable argument is used when this class is used in tests, and
+    // the environment variable is used when this class is used in AWS Lambda
+    // functions.
+    super(usersTable || process.env.UsersTable);
   }
 }
 

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const deprecate = require('depd')('my-module');
+const { log } = require('@cumulus/common');
 const aws = require('@cumulus/common/aws');
 const { getS3Object, promiseS3Upload } = require('@cumulus/common/aws');
 const fs = require('fs-extra');
@@ -739,7 +740,11 @@ async function copyGranuleFile(source, target, options) {
     Key: target.Key
   }, (options || {}));
 
-  return s3.copyObject(params).promise();
+  return s3.copyObject(params).promise()
+    .catch((err) => {
+      log.error(`Failed to copy s3://${source.Bucket}/${source.Key} to s3://${target.Bucket}/${target.Key}`); // eslint-disable-line max-len
+      throw err;
+    });
 }
 
 /**


### PR DESCRIPTION
**Summary:** Add ability to query the API from integration tests

## Addresses

* [CUMULUS-760: Interface for integration test to make API calls](https://bugs.earthdata.nasa.gov/browse/CUMULUS-760)
* [CUMULUS-765: IngestGranuleSuccessSpec tests hard-code bucket names](https://bugs.earthdata.nasa.gov/browse/CUMULUS-765)

## Changes

* Adds basic functions to the `api/testUtils` package that invoke the API Gateway lambda functions.
* Handles request authorization by adding tokens to requests.
* Fixes issues where bucket names were hard-coded in the Ingest Granules integration tests
* Adds an example check to the Ingest Granules integration tests that verifies the newly-ingested granule is available through the Cumulus API