### PR TITLE
CUMULUS-765 Remove hard-coded bucket names from integration tests

### DIFF
--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -185,6 +185,9 @@ mth-2:
     protected:
       name: '{{prefix}}-protected'
       type: protected
+    protected-2:
+      name: '{{prefix}}-protected'
+      type: protected
     public:
       name: '{{prefix}}-public'
       type: public

--- a/example/spec/config.yml
+++ b/example/spec/config.yml
@@ -4,6 +4,17 @@ bucket: cumulus-test-sandbox-internal
 distributionEndpoint: https://example.com/
 ems_provider: CUMULUS
 IngestGranule:
+  IngestGranuleOutput:
+    granules:
+      - files:
+        - bucket: cumulus-test-sandbox-protected
+          filename: "s3://cumulus-test-sandbox-protected/MOD09GQ/2017/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf"
+        - bucket: cumulus-test-sandbox-private
+          filename: "s3://cumulus-test-sandbox-private/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met"
+        - bucket: cumulus-test-sandbox-public
+          filename: "s3://cumulus-test-sandbox-public/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg"
+        - bucket: cumulus-test-sandbox-protected-2
+          filename: "s3://cumulus-test-sandbox-protected-2/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml"
   SyncGranuleOutput:
     granules:
       - files:

--- a/example/spec/ingestGranule/IngestGranule.output.payload.template.json
+++ b/example/spec/ingestGranule/IngestGranule.output.payload.template.json
@@ -8,8 +8,8 @@
       "files": [
         {
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
-          "bucket": "cumulus-test-sandbox-protected",
-          "filename": "s3://cumulus-test-sandbox-protected/MOD09GQ/2017/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
+          "bucket": "this-should-be-replaced-with-protected-bucket-name-in-the-test",
+          "filename": "s3://this-should-be-replaced-with-protected-bucket-name-in-the-test/MOD09GQ/2017/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
           "fileSize": 17865615,
           "path": "cumulus-test-data/pdrs",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}",
@@ -17,8 +17,8 @@
         },
         {
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
-          "bucket": "cumulus-test-sandbox-private",
-          "filename": "s3://cumulus-test-sandbox-private/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
+          "bucket": "this-should-be-replaced-with-private-bucket-name-in-the-test",
+          "filename": "s3://this-should-be-replaced-with-private-bucket-name-in-the-test/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
           "fileSize": 44118,
           "path": "cumulus-test-data/pdrs",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{substring(file.name, 0, 3)}",
@@ -26,17 +26,17 @@
         },
         {
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
-          "bucket": "cumulus-test-sandbox-public",
-          "filename": "s3://cumulus-test-sandbox-public/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
+          "bucket": "this-should-be-replaced-with-public-bucket-name-in-the-test",
+          "filename": "s3://this-should-be-replaced-with-public-bucket-name-in-the-test/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
           "fileSize": 44118,
           "path": "cumulus-test-data/pdrs",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{substring(file.name, 0, 3)}",
           "filepath": "MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg"
         },
         {
-          "filename": "s3://cumulus-test-sandbox-protected-2/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
+          "filename": "s3://this-should-be-replaced-with-protected-2-bucket-name-in-the-test/MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{substring(file.name, 0, 3)}",
-          "bucket": "cumulus-test-sandbox-protected-2",
+          "bucket": "this-should-be-replaced-with-protected-2-bucket-name-in-the-test",
           "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "filepath": "MOD09GQ/MOD/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml"
         }

--- a/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const urljoin = require('url-join');
 const got = require('got');
@@ -15,15 +17,17 @@ const config = loadConfig();
 const lambdaStep = new LambdaStep();
 const taskName = 'IngestGranule';
 
-const syncGranuleOutputFilename = './spec/ingestGranule/SyncGranule.output.payload.template.json';
 const templatedSyncGranuleFilename = templateFile({
-  inputTemplateFilename: syncGranuleOutputFilename,
+  inputTemplateFilename: './spec/ingestGranule/SyncGranule.output.payload.template.json',
   config: config[taskName].SyncGranuleOutput
 });
 const expectedSyncGranulePayload = JSON.parse(fs.readFileSync(templatedSyncGranuleFilename));
 
-const outputPayloadTemplateFilename = './spec/ingestGranule/IngestGranule.output.payload.template.json'; // eslint-disable-line max-len
-const expectedPayload = JSON.parse(fs.readFileSync(outputPayloadTemplateFilename));
+const templatedOutputPayloadFilename = templateFile({
+  inputTemplateFilename: './spec/ingestGranule/IngestGranule.output.payload.template.json',
+  config: config[taskName].IngestGranuleOutput
+});
+const expectedPayload = JSON.parse(fs.readFileSync(templatedOutputPayloadFilename));
 
 describe('The S3 Ingest Granules workflow', () => {
   const inputPayloadFilename = './spec/ingestGranule/IngestGranule.input.payload.json';
@@ -86,23 +90,18 @@ describe('The S3 Ingest Granules workflow', () => {
       await s3().deleteObject({ Bucket: files[3].bucket, Key: files[3].filepath }).promise();
     });
 
-    it('has a payload with updated filename', () => {
-      let i;
-      for (i = 0; i < 4; i += 1) {
-        expect(files[i].filename).toEqual(expectedPayload.granules[0].files[i].filename);
-      }
+    it('has a payload with correct buckets and filenames', () => {
+      files.forEach((file) => {
+        const expectedFile = expectedPayload.granules[0].files.find((f) => f.name === file.name);
+        expect(file.filename).toEqual(expectedFile.filename);
+        expect(file.bucket).toEqual(expectedFile.bucket);
+      });
     });
 
     it('moves files to the bucket folder based on metadata', () => {
       existCheck.forEach((check) => {
         expect(check).toEqual(true);
       });
-    });
-
-    it('moves files to separate protected buckets based on configuration', () => {
-      // Above we checked that the files exist, now show that they are in separate protected buckets
-      expect(files[0].bucket).toEqual('cumulus-test-sandbox-protected');
-      expect(files[3].bucket).toEqual('cumulus-test-sandbox-protected-2');
     });
   });
 
@@ -155,7 +154,7 @@ describe('The S3 Ingest Granules workflow', () => {
 
   describe('the sf-sns-report task has published a sns message and', () => {
     it('the granule record is added to DynamoDB', async () => {
-      const record = await granuleModel.get({ granuleId: inputPayload.granules[0].granuleId }); 
+      const record = await granuleModel.get({ granuleId: inputPayload.granules[0].granuleId });
       expect(record.execution).toEqual(getExecutionUrl(workflowExecution.executionArn));
     });
 


### PR DESCRIPTION
**Summary:** Remove hard-coded bucket names from IngestGranule integration tests

Addresses [CUMULUS-765: IngestGranuleSuccessSpec tests hard-code bucket names](https://bugs.earthdata.nasa.gov/browse/CUMULUS-765)

## Changes

* Remove hard-coded bucket names from IngestGranule integration test