### PR TITLE
Adds distEndpoint to ApiGranulesDefault envs.

### DIFF
--- a/packages/api/config/api_default.yml
+++ b/packages/api/config/api_default.yml
@@ -60,6 +60,7 @@ ApiGranulesDefault:
     invoke:
       function: "Ref"
       value: ScheduleSFLambdaFunction
+    distEndpoint: '{{parent.api_distribution_url}}'
     bucket: '{{parent.system_bucket}}'
     internal: '{{parent.system_bucket}}'
     cmr_provider: '{{parent.cmr.provider}}'


### PR DESCRIPTION
**Summary:** harmonizes `api_v1.yml` and `api_defaults.yml`

Addresses: Nothing ticketed.

## Changes

* adds distEndpoint to api_defaults.yml to match api_vi.yml


## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [x ] Adhoc testing
- [no ] Update CHANGELOG
- [ no ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [no ] Commit `.eslint-ratchet-high-water-mark` if the score has improved


Reviewers: @sisco, @laurenfrederick
