### PR TITLE
Fix discover-pdrs to avoid reliance on collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- **GITC-776-4** - Fixed Discover-pdrs to not rely on collection but use provider_path in config. It also has an optional filterPdrs regex configuration parameter
 - **CUMULUS-746** - Move granule API correctly updates record in dynamo DB and cmr xml file
 
 ## [v1.7.0] - 2018-07-02

--- a/packages/ingest/pdr.js
+++ b/packages/ingest/pdr.js
@@ -24,7 +24,7 @@ class Discover {
   constructor(
     stack,
     bucket,
-    collection,
+    providerPath,
     provider,
     useList = false,
     folder = 'pdrs',
@@ -36,7 +36,6 @@ class Discover {
 
     this.stack = stack;
     this.bucket = bucket;
-    this.collection = collection;
     this.provider = provider;
     this.folder = folder;
     this.useList = useList;
@@ -45,7 +44,7 @@ class Discover {
     // get authentication information
     this.port = get(this.provider, 'port', 21);
     this.host = get(this.provider, 'host', null);
-    this.path = this.collection.provider_path || '/';
+    this.path = providerPath || '/';
     this.username = get(this.provider, 'username', null);
     this.password = get(this.provider, 'password', null);
   }

--- a/tasks/discover-pdrs/index.js
+++ b/tasks/discover-pdrs/index.js
@@ -20,6 +20,9 @@ function discoverPdrs(event) {
     const bucket = config.bucket;
     const collection = config.collection;
     const provider = config.provider;
+    const providerPath = config.provider_path || collection.provider_path;  
+    const filterPdrs = config.filterPdrs || null;
+
     // FIXME Can config.folder not be used?
 
     log.info('Received the provider', { provider: get(provider, 'id') });
@@ -28,7 +31,7 @@ function discoverPdrs(event) {
     const discover = new Discover(
       stack,
       bucket,
-      collection,
+      providerPath,
       provider,
       config.useList,
       'pdrs',
@@ -40,6 +43,14 @@ function discoverPdrs(event) {
     return discover.discover()
       .then((pdrs) => {
         if (discover.connected) discover.end();
+
+        // filter pdrs using filterPDrs
+        if (filterPdrs && pdrs.length) {
+          log.info(`Filtering ${pdrs.length} with ${filterPdrs}`);
+          const fpdrs = pdrs.filter((p) => p.name.match(filterPdrs));
+          return { pdrs: fpdrs };
+        }
+        
         return { pdrs };
       })
       .catch((e) => {

--- a/tasks/discover-pdrs/schemas/config.json
+++ b/tasks/discover-pdrs/schemas/config.json
@@ -4,7 +4,6 @@
   "type": "object",
   "required": [
     "provider",
-    "collection",
     "bucket",
     "stack"
   ],
@@ -49,6 +48,8 @@
       "description": "flag to force the processing of PDR's that have already been discovered",
       "default": false,
       "type": "boolean"
-    }
+    },
+    "filterPdrs": { "type": "string"},
+    "provider_path": { "type": "string"}
   }
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Fix discover-pdrs to avoid reliance on collection been passed in config.  Added optional parameter to filter pdrs.

## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [ ] Adhoc testing
- [x ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

Reviewers: @tag-your-friends