### PR TITLE
don't build api response objects in models

### DIFF
--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -61,7 +61,7 @@ async function put(event) {
   }
 
   if (action === 'applyWorkflow') {
-    const applyWorkflowResult = await granuleModelClient.applyWorkflow(
+    await granuleModelClient.applyWorkflow(
       granule,
       body.workflow,
       body.messageSource,
@@ -71,7 +71,11 @@ async function put(event) {
 
     return buildLambdaProxyResponse({
       json: true,
-      body: applyWorkflowResult
+      body: {
+        granuleId: granule.granuleId,
+        action: `applyWorkflow ${body.workflow}`,
+        status: 'SUCCESS'
+      }
     });
   }
 

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -44,7 +44,7 @@ class Granule extends Manager {
    *
    * @param {string} granuleId - the granule ID
    * @param {string} collectionId - the collection ID
-   * @returns {Promise<undefined>} undefined
+   * @returns {Promise<undefined>} - undefined
    */
   async removeGranuleFromCmr(granuleId, collectionId) {
     log.info(`granules.removeGranuleFromCmr ${granuleId}`);
@@ -64,15 +64,10 @@ class Granule extends Manager {
    * start the re-ingest of a given granule object
    *
    * @param {Object} g - the granule object
-   * @returns {Promise<Object>} an object showing the start of the re-ingest
+   * @returns {Promise<undefined>} - undefined
    */
   async reingest(g) {
     await this.applyWorkflow(g, 'IngestGranule', 'input');
-    return {
-      granuleId: g.granuleId,
-      action: 'reingest',
-      status: 'SUCCESS'
-    };
   }
 
   /**
@@ -83,45 +78,29 @@ class Granule extends Manager {
    * @param {string} messageSource - 'input' or 'output' from previous execution
    * @param {Object} metaOverride - overrides the meta of the new execution, accepts partial override
    * @param {Object} payloadOverride - overrides the payload of the new execution, accepts partial override
-   * @returns {Promise<Object>} an object showing the start of the workflow execution
+   * @returns {Promise<undefined>} - undefined
    */
   async applyWorkflow(g, workflow, messageSource, metaOverride, payloadOverride) {
     const { name, version } = deconstructCollectionId(g.collectionId);
 
-    try {
-      // get the payload of the original execution
-      const status = await aws.StepFunction.getExecutionStatus(path.basename(g.execution));
-      const originalMessage = JSON.parse(status.execution[messageSource]);
-    
-      const payload = await Rule.buildPayload({
-        workflow,
-        provider: g.provider,
-        collection: {
-          name,
-          version
-        },
-        meta: metaOverride ? merge(originalMessage.meta, metaOverride) : originalMessage.meta,
-        payload: payloadOverride ? merge(originalMessage.payload, payloadOverride) : originalMessage.payload
-      });
+    // get the payload of the original execution
+    const status = await aws.StepFunction.getExecutionStatus(path.basename(g.execution));
+    const originalMessage = JSON.parse(status.execution[messageSource]);
 
-      await this.updateStatus({ granuleId: g.granuleId }, 'running');
+    const payload = await Rule.buildPayload({
+      workflow,
+      provider: g.provider,
+      collection: {
+        name,
+        version
+      },
+      meta: metaOverride ? merge(originalMessage.meta, metaOverride) : originalMessage.meta,
+      payload: payloadOverride ? merge(originalMessage.payload, payloadOverride) : originalMessage.payload
+    });
 
-      await aws.invoke(process.env.invoke, payload);
-      return {
-        granuleId: g.granuleId,
-        action: `applyWorkflow ${workflow}`,
-        status: 'SUCCESS'
-      };
-    }
-    catch (e) {
-      log.error(g.granuleId, e);
-      return {
-        granuleId: g.granuleId,
-        action: `applyWorkflow ${workflow}`,
-        status: 'FAILED',
-        error: e.message
-      }
-    }
+    await this.updateStatus({ granuleId: g.granuleId }, 'running');
+
+    await aws.invoke(process.env.invoke, payload);
   }
 
   /**   

--- a/packages/api/tests/test-es-indexer.js
+++ b/packages/api/tests/test-es-indexer.js
@@ -635,9 +635,7 @@ test.serial('reingest a granule', async (t) => {
 
   t.is(record.status, 'completed');
 
-  const response = await indexer.reingest(record);
-  t.is(response.action, 'reingest');
-  t.is(response.status, 'SUCCESS');
+  await indexer.reingest(record);
 
   const g = new models.Granule();
   const newRecord = await g.get({ granuleId: record.granuleId });


### PR DESCRIPTION
**Summary:** Summary of changes

Separate API and Model functionality

## Changes

- Make API endpoint build all response objects
- Remove API response object return values in granules model

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Adhoc testing