### PR TITLE
Fix broken link to deployment documentation

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,7 @@ yarn
 
 ## Running tests locally
 
-These tests run against AWS, so a Cumulus deployment is needed. Set up the deployment using the configurations in this repository. Deployment instructions are located [here](https://cumulus-nasa.github.io/docs/deployment.html). The dashboard is not needed for these tests.
+These tests run against AWS, so a Cumulus deployment is needed. Set up the deployment using the configurations in this repository. Deployment instructions are located [here](https://cumulus-nasa.github.io/deployment/). The dashboard is not needed for these tests.
 
 ### How to configure your test stack
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses bug - broken link to cumulus-nasa.github.io deployment documentation in the examples/readme.md file.

## Changes

* Detailed list or prose of changes
* ...

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
